### PR TITLE
feat(ci): update build-and-publish workflow for conditional pushes

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -24,31 +24,35 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3 
 
-      - name: Build Docker image
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v2
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
         uses: docker/build-push-action@v5 
         id: docker_build
         with:
           context: .
           file: ./Dockerfile
-          load: true # Change to load instead of push
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
             ghcr.io/obeone/crawler-to-md:latest
             docker.io/obeoneorg/crawler-to-md:latest
           platforms: linux/amd64,linux/arm64,linux/i386
-
-      - name: Log in to GitHub Container Registry and push
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          docker push ghcr.io/obeone/crawler-to-md:latest
-
-      - name: Log in to Docker Hub and push
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-          docker push docker.io/obeoneorg/crawler-to-md:latest
 
       - name: Set up cosign
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -20,26 +24,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3 
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3 
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push to GHCR and Docker Hub
+      - name: Build Docker image
         uses: docker/build-push-action@v5 
-        id: build-and-push
+        id: docker_build
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          load: true # Change to load instead of push
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
@@ -47,14 +38,27 @@ jobs:
             docker.io/obeoneorg/crawler-to-md:latest
           platforms: linux/amd64,linux/arm64,linux/i386
 
+      - name: Log in to GitHub Container Registry and push
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker push ghcr.io/obeone/crawler-to-md:latest
+
+      - name: Log in to Docker Hub and push
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          docker push docker.io/obeoneorg/crawler-to-md:latest
+
       - name: Set up cosign
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: sigstore/cosign-installer@v3
 
       - name: Sign the container image with cosign
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           cosign sign --yes ghcr.io/obeone/crawler-to-md@${DIGEST}
           cosign sign --yes docker.io/obeoneorg/crawler-to-md@${DIGEST}
         env:
           COSIGN_EXPERIMENTAL: true
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-
+          DIGEST: ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
- Added triggers for workflow_dispatch and pull_request events.
- Removed direct login and push steps for GitHub Container Registry (GHCR) and Docker Hub in the initial build step.
- Changed the Docker build step to load the image instead of pushing it directly.
- Added conditional steps to log in and push to GHCR and Docker Hub only on push events to the main branch.
- Updated the digest environment variable reference in the cosign sign step to match the new build step id.