### PR TITLE
Trafilatura-2.0

### DIFF
--- a/export_manager.py
+++ b/export_manager.py
@@ -1,8 +1,10 @@
 import json
 from database_manager import DatabaseManager
-import logging  # Add log messages
+import log_setup
 import re
 
+logger = log_setup.get_logger()
+logger.name = "export_manager"
 
 class ExportManager:
     def __init__(self, db_manager: DatabaseManager, title=None):
@@ -14,7 +16,7 @@ class ExportManager:
         """
         self.db_manager = db_manager
         self.title = title
-        logging.info("ExportManager initialized.")  # Add log message
+        logger.info("ExportManager initialized.")  # Add log message
 
     def _adjust_headers(self, content, level_increment=1):
         """
@@ -103,7 +105,7 @@ class ExportManager:
         pages = self.db_manager.get_all_pages()
         with open(output_path, "w", encoding="utf-8") as md_file:
             md_file.write(self._concatenate_markdown(pages))
-        logging.info(
+        logger.info(
             f"Exported pages to markdown file: {output_path}"
         )  # Add log message
 
@@ -132,4 +134,4 @@ class ExportManager:
                 )
             json.dump(data_to_export, json_file, ensure_ascii=False, indent=4)
             # Log the successful export to JSON file
-            logging.info(f"Exported pages to JSON file: {output_path}")
+            logger.info(f"Exported pages to JSON file: {output_path}")

--- a/log_setup.py
+++ b/log_setup.py
@@ -1,7 +1,11 @@
 # log_config.py
 import logging
+from logging import Logger
+from math import exp
 import coloredlogs
 from tqdm import tqdm
+
+logger = Logger("tmp")
 
 class TqdmHandler(logging.StreamHandler):
     """
@@ -37,13 +41,16 @@ def setup_logging(log_level: str = "WARN"):
     Args:
         log_level (str, optional): The minimum log level for messages to be handled. Defaults to "WARN".
     """
+    global logger
+    
     # Get the root logger
     logger = logging.getLogger()
     # Create an instance of the custom TqdmHandler
     handler = TqdmHandler()
     # Define a formatter with a specific format string, including colored output
+    # Updated to show the filename and line number instead of hostname
     formatter = coloredlogs.ColoredFormatter(
-        "%(asctime)s %(hostname)s %(name)s[%(process)d] %(levelname)s %(message)s"
+        "%(asctime)s %(filename)s:%(lineno)d %(name)s[%(process)d] %(levelname)s %(message)s"
     )
     # Set the formatter for the handler
     handler.setFormatter(formatter)
@@ -53,3 +60,15 @@ def setup_logging(log_level: str = "WARN"):
     logger.setLevel(log_level)
     # Install coloredlogs with the specified log level and logger
     coloredlogs.install(level=log_level, logger=logger)
+
+def get_logger():
+    """
+    Returns the global logger instance.
+    
+    Returns:
+        logging.Logger: The global logger instance.
+    """
+    if logger is None:
+        setup_logging()
+    
+    return logger

--- a/main.py
+++ b/main.py
@@ -6,14 +6,14 @@ import os
 log_level = os.getenv("LOG_LEVEL", "WARN")
 log_setup.setup_logging(log_level)
 import argparse
-import logging
 import utils
 from database_manager import DatabaseManager
 from export_manager import ExportManager
 from scraper import Scraper
 import sys
 
-logger = logging.getLogger(__name__)
+logger = log_setup.get_logger()
+logger.name = "main"
 
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-beautifulsoup4==4.12.3                                                                                                           
-coloredlogs==15.0.1                                                                                                                               
-tqdm==4.67.1    
-requests==2.32.3  
-trafilatura==1.10.0
 mdformat==0.7.21
 mdformat-gfm==0.4.1
 mdformat_footnote==0.1.1
 mdformat_frontmatter==2.0.8
 mdformat_tables==1.0.0
+requests==2.32.3
+tqdm==4.67.1
+trafilatura==2.0.0
+coloredlogs==15.0.1

--- a/scraper.py
+++ b/scraper.py
@@ -1,7 +1,7 @@
 import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urljoin, urldefrag
-import logging
+import log_setup
 import trafilatura
 import mdformat
 import json
@@ -10,7 +10,8 @@ from tqdm import tqdm
 import coloredlogs
 
 
-logger = logging.getLogger(__name__)
+logger = log_setup.get_logger()
+logger.name = "Scraper"
 
 
 class Scraper:

--- a/scraper.py
+++ b/scraper.py
@@ -1,3 +1,4 @@
+from curses import meta
 import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urljoin, urldefrag
@@ -109,7 +110,13 @@ class Scraper:
         logger.info(f"Scraping page {url}")
 
         try:
-            metadata = trafilatura.metadata.extract_metadata(html, url).as_dict()
+            metadata = trafilatura.metadata.extract_metadata(filecontent=html, default_url=url).as_dict()
+            
+            if "body" in metadata:
+                metadata.pop("body")
+            if "commentsbody" in metadata:
+                metadata.pop("commentsbody")
+            
             markdown = (
                 trafilatura.extract(
                     html,
@@ -117,7 +124,6 @@ class Scraper:
                     include_formatting=True,
                     include_links=True,
                     include_tables=True,
-                    ansi_color=None,
                 )
                 or ""
             )
@@ -197,6 +203,7 @@ class Scraper:
 
                 # Scrape the page for content and metadata
                 content, metadata = self.scrape_page(html, url)
+
                 # Insert the scraped data into the database
                 self.db_manager.insert_page(url, content, json.dumps(metadata))
 

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,8 @@
-import logging  # Add log messages
+import log_setup  # Add log messages
 from urllib.parse import urlparse, urlunparse
 
+logger = log_setup.get_logger()
+logger.name = "utils"
 
 def randomstring_to_filename(random_string):
     """
@@ -36,7 +38,7 @@ def url_to_filename(url):
         raise ValueError("URL must be a string")
 
     parsed_url = urlparse(url)
-    logging.debug(f"Parsing URL: {url}")  # Log the URL being parsed
+    logger.debug(f"Parsing URL: {url}")  # Log the URL being parsed
 
     # Combine the network location and path, replacing slashes and periods with underscores
     base_filename = parsed_url.netloc + parsed_url.path
@@ -59,7 +61,7 @@ def url_dirname(url):
     str: The URL with the last path segment removed and ending with '/'.
     """
     parsed_url = urlparse(url)
-    logging.debug(f"Parsing URL: {url}")  # Add log message
+    logger.debug(f"Parsing URL: {url}")  # Add log message
 
     # Extract the path segments and remove the last segment
     path_segments = parsed_url.path.rsplit("/", 1)[0]


### PR DESCRIPTION
- Adjusted `trafilatura.metadata.extract_metadata` to use `filecontent` and `default_url`.
- Removed "body" and "commentsbody" keys from metadata if present.
- Removed unused `ansi_color` parameter in `trafilatura.extract`.
- Reorganized requirements to reflect `trafilatura` update to version 2.0.0 and reordered packages.