### PR TITLE
feat(scraper): add rate limiting and delay options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ python main.py --url https://www.example.com
 - Filters links by base URL. 🔍
 - Excludes URLs containing certain strings. ❌
 - Automatically find links or can use a file of URLs to scrape. 🔗
+- Rate limiting and delay 🕘
 - Exports data to Markdown and JSON, ready for GPT uploads. 📤
 - Uses SQLite for efficient data management. 📊
 - Configurable via command-line arguments. ⚙️
@@ -46,13 +47,15 @@ python main.py --url <URL> [--output-folder ./output] [--cache-folder ./cache] [
 
 Options:
 
-- `--url`: The starting URL. 🌍
+- `--url`, `-u`: The starting URL. 🌍
 - `--urls-file`: Path to a file containing URLs to scrape, one URL per line. If '-', read from stdin. 📁
-- `--output-folder`: Where to save Markdown files (default: `./output`). 📂
-- `--cache-folder`: Where to store the database (default: `./cache`). 💾
-- `--base-url`: Filter links by base URL (default: URL's base). 🔎
-- `--exclude`: Exclude URLs containing this string (repeatable). ❌
-- `--title`: Final title of the markdown file. Defaults to the URL. 🏷️
+- `--output-folder`, `-o`: Where to save Markdown files (default: `./output`). 📂
+- `--cache-folder`, `-c`: Where to store the database (default: `./cache`). 💾
+- `--base-url`, `-b`: Filter links by base URL (default: URL's base). 🔎
+- `--title`, `-t`: Final title of the markdown file. Defaults to the URL. 🏷️
+- `--exclude`, `-e`: Exclude URLs containing this string (repeatable). ❌
+- `--rate-limit`, `-rl`: Maximum number of requests per minute (default: 0, no rate limit). ⏱️
+- `--delay`, `-d`: Delay between requests in seconds (default: 0, no delay). 🕒
 
 One of the `--url` or `--urls-file` is required.
 

--- a/main.py
+++ b/main.py
@@ -31,7 +31,9 @@ def main():
     parser.add_argument("--base-url", "-b", help="Base URL for filtering links. Defaults to the URL base")
     parser.add_argument("--title", "-t", help="Final title of the markdown file. Defaults to the URL")
     parser.add_argument("--exclude", "-e", action="append", help="Exclude URLs containing this string", default=[])
-    
+    parser.add_argument("--rate-limit", "-rl", type=int, help="Maximum number of requests per minute", default=0)
+    parser.add_argument("--delay", "-d", type=float, help="Delay between requests in seconds", default=0)
+
     try:
         import argcomplete
         argcomplete.autocomplete(parser)
@@ -85,8 +87,8 @@ def main():
     # Initialize managers
     db_manager = DatabaseManager(os.path.join(args.cache_folder, utils.url_to_filename(args.url if args.url else urls_list[0]) + ".sqlite"))
     logger.info("DatabaseManager initialized.")
-    
-    scraper = Scraper(args.base_url, args.exclude, db_manager)
+
+    scraper = Scraper(base_url=args.base_url, exclude_patterns=args.exclude, db_manager=db_manager, rate_limit=args.rate_limit, delay=args.delay)
     logger.info("Scraper initialized.")
 
     # Start the scraping process


### PR DESCRIPTION
Added rate limiting and delay functionality to the scraping process. Users can now specify the maximum number of requests per minute with `--rate-limit` and set a delay between requests in seconds with `--delay`. Updated README.md and command-line interface to reflect these new options. Modified the Scraper class to implement rate limit tracking and enforce delay between requests.