### PR TITLE
Add overwrite cache option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pip install .
 Start scraping with the following command:
 
 ```shell
-crawler-to-md --url <URL> [--output-folder ./output] [--cache-folder ./cache] [--base-url <BASE_URL>] [--exclude <KEYWORD_IN_URL>] [--title <TITLE>] [--urls-file <URLS_FILE>] [-p <PROXY_URL>]
+crawler-to-md --url <URL> [--output-folder ./output] [--cache-folder ./cache] [--overwrite-cache|-w] [--base-url <BASE_URL>] [--exclude <KEYWORD_IN_URL>] [--title <TITLE>] [--urls-file <URLS_FILE>] [-p <PROXY_URL>]
 ```
 
 Options:
@@ -61,6 +61,7 @@ Options:
 - `--urls-file`: Path to a file containing URLs to scrape, one URL per line. If '-', read from stdin. 📁
 - `--output-folder`, `-o`: Where to save Markdown files (default: `./output`). 📂
 - `--cache-folder`, `-c`: Where to store the database (default: `./cache`). 💾
+- `--overwrite-cache`, `-w`: Overwrite existing cache database before scraping. 🧹
 - `--base-url`, `-b`: Filter links by base URL (default: URL's base). 🔎
 - `--title`, `-t`: Final title of the markdown file. Defaults to the URL. 🏷️
 - `--exclude`, `-e`: Exclude URLs containing this string (repeatable). ❌

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -51,6 +51,13 @@ def main():
         default="~/.cache/crawler-to-md",
     )
     parser.add_argument(
+        "--overwrite-cache",
+        "-w",
+        action="store_true",
+        help="Overwrite existing cache database if present",
+        default=False,
+    )
+    parser.add_argument(
         "--base-url",
         "-b",
         help="Base URL for filtering links. Defaults to the URL base",
@@ -169,6 +176,9 @@ def main():
     db_path = os.path.join(
         args.cache_folder, utils.url_to_filename(first_url) + ".sqlite"
     )
+    if args.overwrite_cache and os.path.exists(db_path):
+        logger.info(f"Removing existing cache database at {db_path}")
+        os.remove(db_path)
     db_manager = DatabaseManager(db_path)
     logger.info("DatabaseManager initialized.")
 

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -178,7 +178,11 @@ def main():
     )
     if args.overwrite_cache and os.path.exists(db_path):
         logger.info(f"Removing existing cache database at {db_path}")
-        os.remove(db_path)
+        try:
+            os.remove(db_path)
+        except OSError as e:
+            logger.error(f"Failed to remove cache database at {db_path}: {e}")
+            sys.exit(1)
     db_manager = DatabaseManager(db_path)
     logger.info("DatabaseManager initialized.")
 


### PR DESCRIPTION
## Summary
- add `--overwrite-cache` CLI flag
- remove existing database when option enabled
- document overwrite-cache flag
- test cache overwrite logic
- add `-w` short argument for overwrite cache

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873c4b0bbe0832ebf801bde6afc445a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line option to overwrite the existing cache database before scraping.
* **Documentation**
  * Updated usage instructions and options list in the README to include the new cache overwrite flag.
* **Tests**
  * Introduced tests to verify correct behavior when the cache overwrite option is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->