### PR TITLE
feat: add html filters for markdown export

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ crawler-to-md --url https://www.example.com
 - Exports each page as an individual Markdown file if `--export-individual` is used. 📝
 - Uses SQLite for efficient data management. 📊
 - Configurable via command-line arguments. ⚙️
+- Include or exclude specific HTML elements using CSS-like selectors (#id, .class, tag) during Markdown conversion. 🧩
 - Docker support. 🐳
 
 ## 📋 Requirements
@@ -52,7 +53,7 @@ pip install .
 Start scraping with the following command:
 
 ```shell
-crawler-to-md --url <URL> [--output-folder ./output] [--cache-folder ./cache] [--overwrite-cache|-w] [--base-url <BASE_URL>] [--exclude <KEYWORD_IN_URL>] [--title <TITLE>] [--urls-file <URLS_FILE>] [-p <PROXY_URL>]
+crawler-to-md --url <URL> [--output-folder ./output] [--cache-folder ./cache] [--overwrite-cache|-w] [--base-url <BASE_URL>] [--exclude-url <KEYWORD_IN_URL>] [--title <TITLE>] [--urls-file <URLS_FILE>] [-p <PROXY_URL>]
 ```
 
 Options:
@@ -64,11 +65,13 @@ Options:
 - `--overwrite-cache`, `-w`: Overwrite existing cache database before scraping. 🧹
 - `--base-url`, `-b`: Filter links by base URL (default: URL's base). 🔎
 - `--title`, `-t`: Final title of the markdown file. Defaults to the URL. 🏷️
-- `--exclude`, `-e`: Exclude URLs containing this string (repeatable). ❌
+- `--exclude-url`, `-e`: Exclude URLs containing this string (repeatable). ❌
 - `--export-individual`, `-ei`: Export each page as an individual Markdown file. 📝
 - `--rate-limit`, `-rl`: Maximum number of requests per minute (default: 0, no rate limit). ⏱️
 - `--delay`, `-d`: Delay between requests in seconds (default: 0, no delay). 🕒
 - `--proxy`, `-p`: Proxy URL for HTTP or SOCKS requests. 🌐
+- `--include`, `-i`: CSS-like selector (#id, .class, tag) to include before Markdown conversion (repeatable). ✅
+- `--exclude`, `-x`: CSS-like selector (#id, .class, tag) to exclude before Markdown conversion (repeatable). 🚫
 
 One of the `--url` or `--urls-file` options is required.
 

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -68,7 +68,7 @@ def main():
         help="Final title of the markdown file. Defaults to the URL",
     )
     parser.add_argument(
-        "--exclude",
+        "--exclude-url",
         "-e",
         action="append",
         help="Exclude URLs containing this string",
@@ -112,6 +112,26 @@ def main():
         action="store_true",
         help="Disable generation of the compiled JSON file",
         default=False,
+    )
+    parser.add_argument(
+        "--include",
+        "-i",
+        action="append",
+        help=(
+            "CSS-like selector (#id, .class, tag) to include before Markdown "
+            "conversion. Repeatable."
+        ),
+        default=[],
+    )
+    parser.add_argument(
+        "--exclude",
+        "-x",
+        action="append",
+        help=(
+            "CSS-like selector (#id, .class, tag) to exclude before Markdown "
+            "conversion. Repeatable."
+        ),
+        default=[],
     )
 
     try:
@@ -189,11 +209,13 @@ def main():
     try:
         scraper = Scraper(
             base_url=args.base_url,
-            exclude_patterns=args.exclude,
+            exclude_patterns=args.exclude_url,
             db_manager=db_manager,
             rate_limit=args.rate_limit,
             delay=args.delay,
             proxy=args.proxy,
+            include_filters=args.include,
+            exclude_filters=args.exclude,
         )
     except ValueError as exc:
         parser.error(str(exc))

--- a/crawler_to_md/scraper.py
+++ b/crawler_to_md/scraper.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import tempfile
@@ -184,10 +185,23 @@ class Scraper:
             soup = BeautifulSoup(html, "html.parser")
 
             if self.include_filters:
+                # Create a new soup to hold the included elements
+                new_soup = BeautifulSoup("", "html.parser")
+                # Ensure the new soup has a body tag if it's a full HTML document
+                if soup.find("body"):
+                    body = new_soup.new_tag("body")
+                    new_soup.append(body)
+                else:
+                    body = new_soup
+
                 elements = []
                 for selector in self.include_filters:
                     elements.extend(self._find_elements(soup, selector))
-                soup = BeautifulSoup("".join(str(el) for el in elements), "html.parser")
+
+                # Append a copy of each element to the new soup to maintain structure
+                for el in elements:
+                    body.append(copy.copy(el))
+                soup = new_soup
 
             for selector in self.exclude_filters:
                 for element in self._find_elements(soup, selector):

--- a/crawler_to_md/scraper.py
+++ b/crawler_to_md/scraper.py
@@ -25,18 +25,23 @@ class Scraper:
         rate_limit=0,
         delay=0,
         proxy=None,
+        include_filters=None,
+        exclude_filters=None,
     ):
         """
-        Initialize the Scraper object.
-        Log the initialization process.
+        Initialize the Scraper object and log the initialization process.
 
         Args:
             base_url (str): The base URL to start scraping from.
-            exclude_patterns (list): List of patterns to exclude from scraping.
+            exclude_patterns (list): List of URL patterns to exclude from scraping.
             db_manager (DatabaseManager): The database manager object.
             rate_limit (int): Maximum number of requests per minute.
             delay (float): Delay between requests in seconds.
             proxy (str, optional): Proxy URL for HTTP or SOCKS requests.
+            include_filters (list, optional): CSS-like selectors (#id, .class, tag)
+                of elements to include before Markdown conversion.
+            exclude_filters (list, optional): CSS-like selectors (#id, .class, tag)
+                of elements to exclude before Markdown conversion.
 
         Raises:
             ValueError: If a proxy is provided but unreachable.
@@ -52,6 +57,9 @@ class Scraper:
             self.session.proxies.update({"http": proxy, "https": proxy})
         self.proxy = proxy
 
+        self.include_filters = include_filters or []
+        self.exclude_filters = exclude_filters or []
+
         if proxy:
             self._test_proxy()
 
@@ -66,6 +74,24 @@ class Scraper:
             self.session.head(self.base_url, timeout=5)
         except requests.RequestException as exc:
             raise ValueError(f"Proxy unreachable: {exc}") from exc
+
+    def _find_elements(self, soup: BeautifulSoup, selector: str):
+        """
+        Locate elements in the soup using a CSS-like selector.
+
+        Args:
+            soup (BeautifulSoup): Parsed HTML document.
+            selector (str): Selector in the form of '#id', '.class', or tag name.
+
+        Returns:
+            list[Tag]: List of matching elements.
+        """
+        if selector.startswith("#"):
+            element = soup.find(id=selector[1:])
+            return [element] if element else []
+        if selector.startswith("."):
+            return soup.find_all(class_=selector[1:])
+        return soup.find_all(selector)
 
     def is_valid_link(self, link):
         """
@@ -157,16 +183,27 @@ class Scraper:
             # Parse the content using BeautifulSoup
             soup = BeautifulSoup(html, "html.parser")
 
+            if self.include_filters:
+                elements = []
+                for selector in self.include_filters:
+                    elements.extend(self._find_elements(soup, selector))
+                soup = BeautifulSoup("".join(str(el) for el in elements), "html.parser")
+
+            for selector in self.exclude_filters:
+                for element in self._find_elements(soup, selector):
+                    element.decompose()
+
             # Extract title from the page
             title = soup.title.string if soup.title else ""
 
             metadata = {"title": title}
 
+            filtered_html = str(soup)
             # Convert the HTML to Markdown
             with tempfile.NamedTemporaryFile(
                 mode="w+", delete=False, suffix=".html"
             ) as tmp:
-                tmp.write(html)
+                tmp.write(filtered_html)
                 tmp_path = tmp.name
 
             markdown = str(MarkItDown().convert(tmp_path))


### PR DESCRIPTION
## Summary
- allow filtering HTML elements with CSS-like selectors via unified include/exclude options
- expose shorthand -i/-x for selector filters and rename URL exclusion to --exclude-url
- document selector usage and cover with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f3068bb14832e8475991938423d7e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command-line options to include or exclude specific HTML elements during Markdown conversion using CSS-like selectors.
  * Renamed the URL exclusion option to improve clarity.

* **Documentation**
  * Updated the README with descriptions and usage examples for the new and renamed command-line options.

* **Tests**
  * Added and updated tests to verify correct handling of the new include and exclude selector options in both the CLI and scraping logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->