### PR TITLE
Add include URL CLI filter

### DIFF
--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -75,6 +75,13 @@ def main():
         default=[],
     )
     parser.add_argument(
+        "--include-url",
+        "-I",
+        action="append",
+        help="Include only URLs containing this string",
+        default=[],
+    )
+    parser.add_argument(
         "--export-individual",
         "-ei",
         action="store_true",
@@ -210,6 +217,7 @@ def main():
         scraper = Scraper(
             base_url=args.base_url,
             exclude_patterns=args.exclude_url,
+            include_url_patterns=args.include_url,
             db_manager=db_manager,
             rate_limit=args.rate_limit,
             delay=args.delay,

--- a/crawler_to_md/scraper.py
+++ b/crawler_to_md/scraper.py
@@ -22,6 +22,7 @@ class Scraper:
         self,
         base_url,
         exclude_patterns,
+        include_url_patterns,
         db_manager: DatabaseManager,
         rate_limit=0,
         delay=0,
@@ -35,6 +36,7 @@ class Scraper:
         Args:
             base_url (str): The base URL to start scraping from.
             exclude_patterns (list): List of URL patterns to exclude from scraping.
+            include_url_patterns (list): List of URL patterns that must be present to scrape.
             db_manager (DatabaseManager): The database manager object.
             rate_limit (int): Maximum number of requests per minute.
             delay (float): Delay between requests in seconds.
@@ -50,6 +52,7 @@ class Scraper:
         logger.debug(f"Initializing Scraper with base URL: {base_url}")
         self.base_url = base_url
         self.exclude_patterns = exclude_patterns or []
+        self.include_url_patterns = include_url_patterns or []
         self.db_manager = db_manager
         self.rate_limit = rate_limit
         self.delay = delay
@@ -107,6 +110,10 @@ class Scraper:
         """
         valid = True
         if self.base_url and not link.startswith(self.base_url):
+            valid = False
+        if self.include_url_patterns and not any(
+            pattern in link for pattern in self.include_url_patterns
+        ):
             valid = False
         for pattern in self.exclude_patterns:
             if pattern in link:


### PR DESCRIPTION
## Summary
- add a new --include-url/-I argument to restrict scraping to URLs containing specified strings
- enforce include URL patterns during link validation and discovery
- extend CLI and scraper tests to cover the new filtering behavior

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c573fd2d0832ea39f942a60acc9f8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--include-url` (`-I`) command-line option to filter crawling to only URLs containing specified strings. This option can be specified multiple times for multiple inclusion patterns, providing complementary filtering alongside existing exclusion options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->