### PR TITLE
Fix crashes, improve scraping resilience, and update UX

### DIFF
--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -103,6 +103,13 @@ def main():
         default=0,
     )
     parser.add_argument(
+        "--timeout",
+        "-T",
+        type=int,
+        help="Request timeout in seconds",
+        default=None,
+    )
+    parser.add_argument(
         "--proxy",
         "-p",
         help="Proxy URL for HTTP or SOCKS requests",
@@ -224,6 +231,7 @@ def main():
             proxy=args.proxy,
             include_filters=args.include,
             exclude_filters=args.exclude,
+            timeout=args.timeout,
         )
     except ValueError as exc:
         parser.error(str(exc))

--- a/crawler_to_md/database_manager.py
+++ b/crawler_to_md/database_manager.py
@@ -31,7 +31,8 @@ class DatabaseManager:
             self.conn.execute(
                 """CREATE TABLE IF NOT EXISTS links (
                           url TEXT PRIMARY KEY,
-                          visited BOOLEAN)"""
+                          visited BOOLEAN,
+                          scraped BOOLEAN DEFAULT FALSE)"""
             )
 
     def insert_page(self, url, content, metadata):
@@ -129,6 +130,19 @@ class DatabaseManager:
                 "SELECT COUNT(*) FROM links WHERE visited = TRUE"
             )
             return cursor.fetchone()[0]
+
+    def mark_link_scraped(self, url):
+        """
+        Mark a link as successfully scraped in the 'links' table.
+
+        Args:
+        url (str): The URL of the link to mark as scraped.
+        """
+        with self.conn:
+            logger.debug(f"Marking link as scraped with URL: {url}")
+            self.conn.execute(
+                "UPDATE links SET scraped = TRUE WHERE url = ?", (url,)
+            )
 
     def get_all_pages(self):
         """

--- a/crawler_to_md/export_manager.py
+++ b/crawler_to_md/export_manager.py
@@ -151,6 +151,8 @@ class ExportManager:
         os.makedirs(output_folder, exist_ok=True)
         for page in pages:
             url, content, metadata = page
+            if content is None:
+                continue  # Skip empty pages
             logger.debug(f"Exporting individual Markdown for URL: {url}")
 
             # Remove base_url from parsed URL if provided

--- a/crawler_to_md/scraper.py
+++ b/crawler_to_md/scraper.py
@@ -326,7 +326,12 @@ class Scraper:
                 url = link[0]  # Extract the URL from the link tuple
 
                 # Attempt to fetch the page content
-                response = self.session.get(url, timeout=self.timeout)
+                try:
+                    response = self.session.get(url, timeout=self.timeout)
+                except requests.RequestException as e:
+                    logger.error(f"Error fetching {url}: {e}")
+                    self.db_manager.mark_link_visited(url)
+                    continue
 
                 # Increment request count for rate limiting
                 request_count += 1
@@ -351,6 +356,7 @@ class Scraper:
 
                 # Insert the scraped data into the database
                 self.db_manager.insert_page(url, content, json.dumps(metadata))
+                self.db_manager.mark_link_scraped(url)
 
                 # Fetch and insert new links found on the page,
                 # if not working from a predefined list

--- a/crawler_to_md/scraper.py
+++ b/crawler_to_md/scraper.py
@@ -29,6 +29,7 @@ class Scraper:
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Initialize the Scraper object and log the initialization process.
@@ -63,6 +64,7 @@ class Scraper:
 
         self.include_filters = include_filters or []
         self.exclude_filters = exclude_filters or []
+        self.timeout = timeout
 
         if proxy:
             self._test_proxy()
@@ -137,7 +139,7 @@ class Scraper:
         try:
             if not html:
                 # Send a GET request to the URL
-                response = self.session.get(url)
+                response = self.session.get(url, timeout=self.timeout)
                 if response.status_code != 200:
                     logger.warning(
                         f"Failed to fetch {url} with status code {response.status_code}"
@@ -324,7 +326,7 @@ class Scraper:
                 url = link[0]  # Extract the URL from the link tuple
 
                 # Attempt to fetch the page content
-                response = self.session.get(url)
+                response = self.session.get(url, timeout=self.timeout)
 
                 # Increment request count for rate limiting
                 request_count += 1

--- a/crawler_to_md/scraper.py
+++ b/crawler_to_md/scraper.py
@@ -282,11 +282,17 @@ class Scraper:
             initial=self.db_manager.get_visited_links_count(),
             desc="Scraping",
             unit="link",
+            position=0,
+        )
+        status_line = tqdm(
+            bar_format="{desc}",
+            position=1,
         )
 
         # Initialize rate limit tracking variables
         request_count = 0
         start_time = time.time()
+        stats = {"ok": 0, "err": 0, "skip": 0}
 
         # Begin the scraping loop
         while True:
@@ -322,13 +328,16 @@ class Scraper:
                     )
                     time.sleep(self.delay)
 
-                pbar.update(1)  # Update the progress bar
                 url = link[0]  # Extract the URL from the link tuple
+                status_line.set_description_str(f"  \u2937 {url}")
 
                 # Attempt to fetch the page content
                 try:
                     response = self.session.get(url, timeout=self.timeout)
                 except requests.RequestException as e:
+                    stats["err"] += 1
+                    pbar.set_postfix(stats, refresh=False)
+                    pbar.update(1)
                     logger.error(f"Error fetching {url}: {e}")
                     self.db_manager.mark_link_visited(url)
                     continue
@@ -341,6 +350,9 @@ class Scraper:
                     "content-type", ""
                 ).startswith("text/html"):
                     # Mark the link as visited and log the reason for skipping
+                    stats["skip"] += 1
+                    pbar.set_postfix(stats, refresh=False)
+                    pbar.update(1)
                     self.db_manager.mark_link_visited(url)
                     logger.info(
                         "Skipping link %s due to invalid status code or content type",
@@ -357,6 +369,9 @@ class Scraper:
                 # Insert the scraped data into the database
                 self.db_manager.insert_page(url, content, json.dumps(metadata))
                 self.db_manager.mark_link_scraped(url)
+                stats["ok"] += 1
+                pbar.set_postfix(stats, refresh=False)
+                pbar.update(1)
 
                 # Fetch and insert new links found on the page,
                 # if not working from a predefined list
@@ -380,5 +395,6 @@ class Scraper:
                 # Mark the current link as visited in the database
                 self.db_manager.mark_link_visited(url)
 
-        # Close the progress bar upon completion of the scraping process
+        # Close the progress bars upon completion of the scraping process
+        status_line.close()
         pbar.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,7 @@ def test_cli_proxy_option(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Fake initializer to capture proxy argument.
@@ -110,6 +111,7 @@ def test_cli_proxy_short_option(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Fake initializer to capture proxy argument.
@@ -155,6 +157,7 @@ def test_cli_socks_proxy(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Fake initializer to capture proxy argument.
@@ -229,6 +232,7 @@ def test_cli_include_exclude_options(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Fake initializer to capture include/exclude arguments.
@@ -286,6 +290,7 @@ def test_cli_include_exclude_short_options(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Capture include and exclude selectors from short options.
@@ -343,6 +348,7 @@ def test_cli_include_url_option(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Capture include URL patterns argument.

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -24,6 +24,9 @@ class DummyDB(DatabaseManager):
     def mark_link_visited(self, url):
         pass
 
+    def mark_link_scraped(self, url):
+        pass
+
 
 def test_is_valid_link():
     db = DummyDB()
@@ -192,6 +195,7 @@ class ListDB(DummyDB):
     def __init__(self):
         self.links = []
         self.visited = set()
+        self.scraped = set()
         self.pages = []
 
     def insert_link(self, url, visited=False):
@@ -208,6 +212,9 @@ class ListDB(DummyDB):
 
     def mark_link_visited(self, url):
         self.visited.add(url)
+
+    def mark_link_scraped(self, url):
+        self.scraped.add(url)
 
     def get_links_count(self):
         return len(self.links)
@@ -242,7 +249,7 @@ def test_start_scraping_process(monkeypatch):
         content = b'<html></html>'
         text = '<html></html>'
 
-    monkeypatch.setattr(scraper.session, 'get', lambda url: DummyResp())
+    monkeypatch.setattr(scraper.session, 'get', lambda url, **kw: DummyResp())
 
     class DummyTqdm:
         def __init__(self, *a, **k):
@@ -346,7 +353,7 @@ def test_start_scraping_excludes_invalid_urls(monkeypatch):
         content = b'<html></html>'
         text = '<html></html>'
 
-    monkeypatch.setattr(scraper.session, 'get', lambda url: DummyResp())
+    monkeypatch.setattr(scraper.session, 'get', lambda url, **kw: DummyResp())
 
     class DummyTqdm:
         def __init__(self, *a, **k):
@@ -393,7 +400,7 @@ def test_start_scraping_filters_discovered_links(monkeypatch):
         headers = {'content-type': 'text/html'}
         text = html
 
-    monkeypatch.setattr(scraper.session, 'get', lambda url: DummyResp())
+    monkeypatch.setattr(scraper.session, 'get', lambda url, **kw: DummyResp())
 
     monkeypatch.setattr(
         Scraper, 'scrape_page', lambda self, html, url: ('# MD', {'url': url})

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -260,6 +260,12 @@ def test_start_scraping_process(monkeypatch):
             pass
         def close(self):
             pass
+        def set_postfix(self, *a, **k):
+            pass
+        def set_postfix_str(self, *a, **k):
+            pass
+        def set_description_str(self, *a, **k):
+            pass
 
     monkeypatch.setattr(tqdm, 'tqdm', lambda *a, **k: DummyTqdm(*a, **k))
 
@@ -364,6 +370,12 @@ def test_start_scraping_excludes_invalid_urls(monkeypatch):
             pass
         def close(self):
             pass
+        def set_postfix(self, *a, **k):
+            pass
+        def set_postfix_str(self, *a, **k):
+            pass
+        def set_description_str(self, *a, **k):
+            pass
 
     monkeypatch.setattr(tqdm, 'tqdm', lambda *a, **k: DummyTqdm(*a, **k))
 
@@ -414,6 +426,12 @@ def test_start_scraping_filters_discovered_links(monkeypatch):
         def refresh(self):
             pass
         def close(self):
+            pass
+        def set_postfix(self, *a, **k):
+            pass
+        def set_postfix_str(self, *a, **k):
+            pass
+        def set_description_str(self, *a, **k):
             pass
 
     monkeypatch.setattr(tqdm, 'tqdm', lambda *a, **k: DummyTqdm(*a, **k))


### PR DESCRIPTION



  - **Fix `TypeError` when exporting individual markdown** for pages with `None` content (e.g. failed fetches, non-HTML resources). The other two export methods already had this guard.
  - **Add `--timeout` / `-T` CLI option** for request timeouts. Default is `None` (no timeout, matching original behavior).
  - **Add `scraped` column to links table** to distinguish between pages that were visited vs successfully scraped. Wrap `session.get()` in try/except so network errors don't crash the scraping loop.
  - **Improve progress bar** with a second status line showing the current URL being fetched, and `ok`/`err`/`skip` counters tracking outcomes:
    - `ok`: page successfully scraped
    - `err`: request failed (timeout, connection error, DNS failure)
    - `skip`: request succeeded but page unusable (non-200 or non-HTML content type)
