### PR TITLE
feat(crawler): improve crawl resilience and add AI-focused markdown minification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,158 @@
+# AGENTS.md
+
+## 0) Scope
+
+For coding agents in `crawler-to-md`.
+Primary goals -> run correct commands, preserve repo behavior, touch matching tests.
+
+Includes:
+
+- build/lint/test commands (incl. single test)
+- repo conventions + invariants
+- CI/release context
+- Cursor/Copilot rule-file status
+
+## 1) Repo Map
+
+Code (`crawler_to_md/`):
+
+- `cli.py` -> CLI args + orchestration
+- `scraper.py` -> crawl loop, HTTP, filters, markdown conversion
+- `database_manager.py` -> SQLite schema + persistence API
+- `export_manager.py` -> combined markdown/json + per-page markdown export
+- `utils.py` -> URL/path/filename helpers
+- `log_setup.py` -> logging setup (tqdm-friendly)
+
+Tests: `tests/**`
+
+Key config/automation:
+
+- `pyproject.toml`
+- `Dockerfile`
+- `.github/workflows/build-and-publish.yaml`
+- `.github/workflows/publish-to-pypi.yaml`
+
+## 2) Environment
+
+- Python -> `>=3.10`
+- Packaging -> `setuptools` + `setuptools_scm`
+- Lint/import sorting -> `ruff` (`E,F,W,I`)
+- Tests -> `pytest`
+
+Local setup:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip
+pip install -e .
+pip install pytest ruff build twine
+```
+
+Note -> `pytest`/`ruff` configured but not exposed as dev extras.
+
+## 3) Canonical Commands
+
+Run CLI:
+
+```bash
+crawler-to-md --url https://example.com
+python -m crawler_to_md.cli --url https://example.com
+```
+
+Lint:
+
+```bash
+ruff check .
+ruff check . --fix
+```
+
+Tests:
+
+```bash
+pytest
+pytest tests/test_utils.py
+pytest tests/test_utils.py::test_url_to_filename
+pytest -k proxy
+pytest -x
+pytest -v
+```
+
+Build/package:
+
+```bash
+python -m build
+twine check dist/*
+```
+
+Docker (local):
+
+```bash
+docker build -t crawler-to-md .
+docker run --rm -v "$(pwd)/output:/app/output" crawler-to-md --url https://example.com
+```
+
+## 4) Conventions + Invariants (Do Not Drift)
+
+Formatting/imports:
+
+- line length -> `88`
+- imports -> Ruff `I` compliant
+- after import/format changes -> run `ruff check . --fix`
+
+Naming/ownership:
+
+- naming -> `snake_case` (modules/functions/vars), `PascalCase` (classes)
+- keep logic boundaries:
+  - DB logic -> `DatabaseManager`
+  - export logic -> `ExportManager`
+  - crawl/scrape logic -> `Scraper`
+
+Error handling:
+
+- invalid caller input -> `ValueError`
+- CLI user-facing arg/config errors -> `parser.error(...)`
+- network/proxy boundary failures -> handle `requests` exceptions + log context
+- never silently swallow failures
+
+File/data:
+
+- create output/cache dirs before writes
+- text output encoding -> UTF-8
+- preserve DB semantics in `database_manager.py`:
+  - `pages(url, content, metadata)`
+  - `links(url, visited)`
+- keep idempotent insert behavior unless intentionally changing semantics
+
+Scraping behavior:
+
+- preserve URL include/exclude semantics
+- preserve CSS include/exclude semantics before markdown conversion
+- skip non-200 or non-HTML responses
+- preserve rate-limit + delay behavior
+
+## 5) Test Mapping + Done Criteria
+
+Change -> tests to update/run:
+
+- CLI flags/options -> `tests/test_cli.py`
+- scraping/link/proxy/filter behavior -> `tests/test_scraper.py`
+- DB behavior -> `tests/test_database_manager.py`
+- markdown/json export behavior -> `tests/test_export_manager.py`
+- helpers/utilities -> `tests/test_utils.py`
+
+Before finishing non-trivial work:
+
+1. `ruff check .`
+2. targeted pytest (single test or file)
+3. full `pytest` for cross-cutting changes
+4. `python -m build` if packaging/release behavior changed
+
+## 6) CI/Release Reality
+
+Workflows present:
+
+- Docker build/publish/sign
+- PyPI publish on release
+
+No dedicated workflow here runs lint/tests on every PR by default -> run checks locally.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install .
 Start scraping with the following command:
 
 ```shell
-crawler-to-md --url <URL> [--output-folder ./output] [--cache-folder ./cache] [--overwrite-cache|-w] [--base-url <BASE_URL>] [--exclude-url <KEYWORD_IN_URL>] [--title <TITLE>] [--urls-file <URLS_FILE>] [-p <PROXY_URL>]
+crawler-to-md --url <URL> [--output-folder ./output] [--cache-folder ~/.cache/crawler-to-md] [--overwrite-cache|-w] [--base-url <BASE_URL>] [--exclude-url <KEYWORD_IN_URL>] [--include-url <KEYWORD_IN_URL>] [--title <TITLE>] [--urls-file <URLS_FILE>] [--timeout <SECONDS>] [-p <PROXY_URL>] [--no-markdown] [--no-json] [--minify|-m]
 ```
 
 Options:
@@ -61,15 +61,20 @@ Options:
 - `--url`, `-u`: The starting URL. 🌍
 - `--urls-file`: Path to a file containing URLs to scrape, one URL per line. If '-', read from stdin. 📁
 - `--output-folder`, `-o`: Where to save Markdown files (default: `./output`). 📂
-- `--cache-folder`, `-c`: Where to store the database (default: `./cache`). 💾
+- `--cache-folder`, `-c`: Where to store the database (default: `~/.cache/crawler-to-md`). 💾
 - `--overwrite-cache`, `-w`: Overwrite existing cache database before scraping. 🧹
 - `--base-url`, `-b`: Filter links by base URL (default: URL's base). 🔎
 - `--title`, `-t`: Final title of the markdown file. Defaults to the URL. 🏷️
 - `--exclude-url`, `-e`: Exclude URLs containing this string (repeatable). ❌
+- `--include-url`, `-I`: Include only URLs containing this string (repeatable). 🔍
 - `--export-individual`, `-ei`: Export each page as an individual Markdown file. 📝
 - `--rate-limit`, `-rl`: Maximum number of requests per minute (default: 0, no rate limit). ⏱️
 - `--delay`, `-d`: Delay between requests in seconds (default: 0, no delay). 🕒
 - `--proxy`, `-p`: Proxy URL for HTTP or SOCKS requests. 🌐
+- `--timeout`: Request timeout in seconds (default: `10`). ⌛
+- `--no-markdown`: Disable generation of the compiled Markdown file. 🚫📝
+- `--no-json`: Disable generation of the compiled JSON file. 🚫🧾
+- `--minify`, `-m`: Minify generated Markdown output for AI ingestion/content backup (not rendering fidelity). 🧠
 - `--include`, `-i`: CSS-like selector (#id, .class, tag) to include before Markdown conversion (repeatable). ✅
 - `--exclude`, `-x`: CSS-like selector (#id, .class, tag) to exclude before Markdown conversion (repeatable). 🚫
 

--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ pip install .
 Start scraping with the following command:
 
 ```shell
-crawler-to-md --url <URL> [--output-folder ./output] [--cache-folder ~/.cache/crawler-to-md] [--overwrite-cache|-w] [--base-url <BASE_URL>] [--exclude-url <KEYWORD_IN_URL>] [--include-url <KEYWORD_IN_URL>] [--title <TITLE>] [--urls-file <URLS_FILE>] [--timeout <SECONDS>] [-p <PROXY_URL>] [--no-markdown] [--no-json] [--minify|-m]
+crawler-to-md --url <URL> [--output-folder|--output-dir ./output] [--cache-folder|--cache-dir ~/.cache/crawler-to-md] [--overwrite-cache|-w] [--base-url <BASE_URL>] [--exclude-url <KEYWORD_IN_URL>] [--include-url <KEYWORD_IN_URL>] [--title <TITLE>] [--urls-file <URLS_FILE>] [--timeout <SECONDS>] [-p <PROXY_URL>] [--no-markdown] [--no-json] [--minify|-m]
 ```
 
 Options:
 
 - `--url`, `-u`: The starting URL. 🌍
 - `--urls-file`: Path to a file containing URLs to scrape, one URL per line. If '-', read from stdin. 📁
-- `--output-folder`, `-o`: Where to save Markdown files (default: `./output`). 📂
-- `--cache-folder`, `-c`: Where to store the database (default: `~/.cache/crawler-to-md`). 💾
+- `--output-folder`, `--output-dir`, `-o`: Where to save Markdown files (default: `./output`). 📂
+- `--cache-folder`, `--cache-dir`, `-c`: Where to store the database (default: `~/.cache/crawler-to-md`). 💾
 - `--overwrite-cache`, `-w`: Overwrite existing cache database before scraping. 🧹
 - `--base-url`, `-b`: Filter links by base URL (default: URL's base). 🔎
 - `--title`, `-t`: Final title of the markdown file. Defaults to the URL. 🏷️
@@ -79,6 +79,42 @@ Options:
 - `--exclude`, `-x`: CSS-like selector (#id, .class, tag) to exclude before Markdown conversion (repeatable). 🚫
 
 One of the `--url` or `--urls-file` options is required.
+
+### ✅ Common commands
+
+Basic crawl:
+
+```shell
+crawler-to-md --url https://www.example.com
+```
+
+AI-ready Markdown only (compact output):
+
+```shell
+crawler-to-md --url https://www.example.com --minify --no-json
+```
+
+Ignore cache and rescrape from scratch:
+
+```shell
+crawler-to-md --url https://www.example.com --overwrite-cache
+```
+
+Read URLs from a file:
+
+```shell
+crawler-to-md --urls-file urls.txt
+```
+
+### 🗂️ Output behavior
+
+- Compiled Markdown and JSON outputs are overwritten if files already exist.
+- `--export-individual` writes per-page files under the `files/` subfolder.
+
+### 🧠 Minify mode
+
+`--minify` is designed for AI ingestion/content backup and not for rendering fidelity.
+It keeps fenced code blocks intact and compacts Markdown outside fences.
 
 ### 📚 Log level
 

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -130,8 +130,8 @@ def main():
         "-i",
         action="append",
         help=(
-            "CSS-like selector (#id, .class, tag) to include before Markdown "
-            "conversion. Repeatable."
+            "CSS-like selector (#id, .class, tag only) to include before "
+            "Markdown conversion. Repeatable."
         ),
         default=[],
     )
@@ -140,8 +140,8 @@ def main():
         "-x",
         action="append",
         help=(
-            "CSS-like selector (#id, .class, tag) to exclude before Markdown "
-            "conversion. Repeatable."
+            "CSS-like selector (#id, .class, tag only) to exclude before "
+            "Markdown conversion. Repeatable."
         ),
         default=[],
     )

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -39,12 +39,14 @@ def main():
     )
     parser.add_argument(
         "--output-folder",
+        "--output-dir",
         "-o",
         help="Output folder for the markdown file",
         default="./output",
     )
     parser.add_argument(
         "--cache-folder",
+        "--cache-dir",
         "-c",
         help="Cache folder for storing database",
         default="~/.cache/crawler-to-md",

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -126,6 +126,16 @@ def main():
         default=False,
     )
     parser.add_argument(
+        "--minify",
+        "-m",
+        action="store_true",
+        help=(
+            "Minify generated Markdown output (.md) for AI ingestion or content "
+            "backup (not rendering fidelity)."
+        ),
+        default=False,
+    )
+    parser.add_argument(
         "--include",
         "-i",
         action="append",
@@ -238,7 +248,7 @@ def main():
     output_name = utils.randomstring_to_filename(args.title)
 
     # After the scraping process is completed in the main function
-    export_manager = ExportManager(db_manager, args.title)
+    export_manager = ExportManager(db_manager, args.title, minify=args.minify)
     logger.info("ExportManager initialized.")
 
     if not args.no_markdown:

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -29,7 +29,6 @@ def main():
     """
     logger.info("Starting the web scraper application.")
 
-
     # Parse command line arguments
     parser = argparse.ArgumentParser(description="Web Scraper to Markdown")
     parser.add_argument("--url", "-u", help="Base URL to start scraping")
@@ -109,6 +108,12 @@ def main():
         default=None,
     )
     parser.add_argument(
+        "--timeout",
+        type=float,
+        help="Request timeout in seconds",
+        default=10,
+    )
+    parser.add_argument(
         "--no-markdown",
         action="store_true",
         help="Disable generation of the compiled Markdown file",
@@ -144,11 +149,9 @@ def main():
     try:
         import argcomplete
 
-
         argcomplete.autocomplete(parser)
     except ImportError:
         pass
-
 
     args = parser.parse_args()
     logger.debug(f"Command line arguments parsed: {args}")
@@ -165,12 +168,10 @@ def main():
             with open(args.urls_file, "r") as file:
                 urls_list = [line.strip() for line in file.readlines()]
 
-
         urls_list = utils.deduplicate_list(urls_list)
         args.url = None  # Ensure args.url is defined even if not used
     else:
         urls_list = []
-
 
     if not args.url and not urls_list:
         parser.error("No URL provided. Please provide either --url or --urls-file.")
@@ -221,6 +222,7 @@ def main():
             db_manager=db_manager,
             rate_limit=args.rate_limit,
             delay=args.delay,
+            timeout=args.timeout,
             proxy=args.proxy,
             include_filters=args.include,
             exclude_filters=args.exclude,
@@ -238,7 +240,6 @@ def main():
     # After the scraping process is completed in the main function
     export_manager = ExportManager(db_manager, args.title)
     logger.info("ExportManager initialized.")
-
 
     if not args.no_markdown:
         export_manager.export_to_markdown(os.path.join(output, f"{output_name}.md"))

--- a/crawler_to_md/scraper.py
+++ b/crawler_to_md/scraper.py
@@ -26,6 +26,7 @@ class Scraper:
         db_manager: DatabaseManager,
         rate_limit=0,
         delay=0,
+        timeout=10,
         proxy=None,
         include_filters=None,
         exclude_filters=None,
@@ -41,6 +42,7 @@ class Scraper:
             db_manager (DatabaseManager): The database manager object.
             rate_limit (int): Maximum number of requests per minute.
             delay (float): Delay between requests in seconds.
+            timeout (float): Request timeout in seconds.
             proxy (str, optional): Proxy URL for HTTP or SOCKS requests.
             include_filters (list, optional): CSS-like selectors (#id, .class, tag)
                 of elements to include before Markdown conversion.
@@ -57,6 +59,7 @@ class Scraper:
         self.db_manager = db_manager
         self.rate_limit = rate_limit
         self.delay = delay
+        self.timeout = timeout
         self.session = requests.Session()
         if proxy:
             self.session.proxies.update({"http": proxy, "https": proxy})
@@ -76,7 +79,7 @@ class Scraper:
             ValueError: If the proxy cannot fetch the base URL.
         """
         try:
-            self.session.head(self.base_url, timeout=5)
+            self.session.head(self.base_url, timeout=self.timeout)
         except requests.RequestException as exc:
             raise ValueError(f"Proxy unreachable: {exc}") from exc
 
@@ -157,7 +160,7 @@ class Scraper:
         try:
             if not html:
                 # Send a GET request to the URL
-                response = self.session.get(url)
+                response = self.session.get(url, timeout=self.timeout)
                 if response.status_code != 200:
                     logger.warning(
                         f"Failed to fetch {url} with status code {response.status_code}"
@@ -350,7 +353,7 @@ class Scraper:
 
                 # Attempt to fetch the page content
                 try:
-                    response = self.session.get(url)
+                    response = self.session.get(url, timeout=self.timeout)
                     # Increment request count for rate limiting
                     request_count += 1
                 except requests.RequestException as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -532,3 +532,13 @@ def test_cli_help_mentions_timeout(monkeypatch, capsys):
 
     help_output = capsys.readouterr().out
     assert "--timeout" in help_output
+
+
+def test_cli_help_mentions_simple_selector_forms(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["prog", "--help"])
+
+    with pytest.raises(SystemExit):
+        cli.main()
+
+    help_output = capsys.readouterr().out
+    assert "#id, .class, tag only" in help_output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -542,3 +542,115 @@ def test_cli_help_mentions_simple_selector_forms(monkeypatch, capsys):
 
     help_output = capsys.readouterr().out
     assert "#id, .class, tag only" in help_output
+
+
+def test_cli_minify_option_passed_to_export_manager(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_init(self, db_manager, title=None, minify=False):
+        captured["minify"] = minify
+        self.db_manager = db_manager
+        self.title = title
+        self.minify = minify
+
+    monkeypatch.setattr(ExportManager, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
+
+    cache_folder = tmp_path / "cache"
+    args = [
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
+        str(tmp_path),
+        "--cache-folder",
+        str(cache_folder),
+        "--minify",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    cli.main()
+
+    assert captured.get("minify") is True
+
+
+def test_cli_minify_short_option_passed_to_export_manager(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_init(self, db_manager, title=None, minify=False):
+        captured["minify"] = minify
+        self.db_manager = db_manager
+        self.title = title
+        self.minify = minify
+
+    monkeypatch.setattr(ExportManager, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
+
+    cache_folder = tmp_path / "cache"
+    args = [
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
+        str(tmp_path),
+        "--cache-folder",
+        str(cache_folder),
+        "-m",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    cli.main()
+
+    assert captured.get("minify") is True
+
+
+def test_cli_help_mentions_minify(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["prog", "--help"])
+
+    with pytest.raises(SystemExit):
+        cli.main()
+
+    help_output = capsys.readouterr().out
+    assert "--minify" in help_output
+    assert "backup" in help_output
+    assert "rendering" in help_output
+
+
+def test_cli_minify_default_false(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_init(self, db_manager, title=None, minify=False):
+        captured["minify"] = minify
+        self.db_manager = db_manager
+        self.title = title
+        self.minify = minify
+
+    monkeypatch.setattr(ExportManager, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
+
+    cache_folder = tmp_path / "cache"
+    args = [
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
+        str(tmp_path),
+        "--cache-folder",
+        str(cache_folder),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    cli.main()
+
+    assert captured.get("minify") is False
+
+
+def test_cli_minify_with_no_markdown_has_no_markdown_side_effects(
+    monkeypatch, tmp_path
+):
+    calls = _run_cli(monkeypatch, tmp_path, ["--minify", "--no-markdown"])
+    assert calls["md"] is False
+    assert calls["json"] is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,7 @@ def test_cli_proxy_option(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Fake initializer to capture proxy argument.
@@ -72,28 +73,28 @@ def test_cli_proxy_option(monkeypatch, tmp_path):
         Args:
             proxy (str, optional): Proxy URL.
         """
-        captured['proxy'] = proxy
+        captured["proxy"] = proxy
 
-    monkeypatch.setattr(Scraper, '__init__', fake_init)
-    monkeypatch.setattr(Scraper, 'start_scraping', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_markdown', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_json', lambda *a, **k: None)
+    monkeypatch.setattr(Scraper, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
 
-    cache_folder = tmp_path / 'cache'
+    cache_folder = tmp_path / "cache"
     args = [
-        'prog',
-        '--url',
-        'http://example.com',
-        '--output-folder',
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
         str(tmp_path),
-        '--cache-folder',
+        "--cache-folder",
         str(cache_folder),
-        '--proxy',
-        'http://proxy:8080',
+        "--proxy",
+        "http://proxy:8080",
     ]
-    monkeypatch.setattr(sys, 'argv', args)
+    monkeypatch.setattr(sys, "argv", args)
     cli.main()
-    assert captured.get('proxy') == 'http://proxy:8080'
+    assert captured.get("proxy") == "http://proxy:8080"
 
 
 def test_cli_proxy_short_option(monkeypatch, tmp_path):
@@ -110,6 +111,7 @@ def test_cli_proxy_short_option(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Fake initializer to capture proxy argument.
@@ -117,28 +119,28 @@ def test_cli_proxy_short_option(monkeypatch, tmp_path):
         Args:
             proxy (str, optional): Proxy URL.
         """
-        captured['proxy'] = proxy
+        captured["proxy"] = proxy
 
-    monkeypatch.setattr(Scraper, '__init__', fake_init)
-    monkeypatch.setattr(Scraper, 'start_scraping', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_markdown', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_json', lambda *a, **k: None)
+    monkeypatch.setattr(Scraper, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
 
-    cache_folder = tmp_path / 'cache'
+    cache_folder = tmp_path / "cache"
     args = [
-        'prog',
-        '--url',
-        'http://example.com',
-        '--output-folder',
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
         str(tmp_path),
-        '--cache-folder',
+        "--cache-folder",
         str(cache_folder),
-        '-p',
-        'http://proxy:8080',
+        "-p",
+        "http://proxy:8080",
     ]
-    monkeypatch.setattr(sys, 'argv', args)
+    monkeypatch.setattr(sys, "argv", args)
     cli.main()
-    assert captured.get('proxy') == 'http://proxy:8080'
+    assert captured.get("proxy") == "http://proxy:8080"
 
 
 def test_cli_socks_proxy(monkeypatch, tmp_path):
@@ -155,6 +157,7 @@ def test_cli_socks_proxy(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Fake initializer to capture proxy argument.
@@ -162,48 +165,48 @@ def test_cli_socks_proxy(monkeypatch, tmp_path):
         Args:
             proxy (str, optional): Proxy URL.
         """
-        captured['proxy'] = proxy
+        captured["proxy"] = proxy
 
-    monkeypatch.setattr(Scraper, '__init__', fake_init)
-    monkeypatch.setattr(Scraper, 'start_scraping', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_markdown', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_json', lambda *a, **k: None)
+    monkeypatch.setattr(Scraper, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
 
-    cache_folder = tmp_path / 'cache'
+    cache_folder = tmp_path / "cache"
     args = [
-        'prog',
-        '--url',
-        'http://example.com',
-        '--output-folder',
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
         str(tmp_path),
-        '--cache-folder',
+        "--cache-folder",
         str(cache_folder),
-        '--proxy',
-        'socks5://localhost:9050',
+        "--proxy",
+        "socks5://localhost:9050",
     ]
-    monkeypatch.setattr(sys, 'argv', args)
+    monkeypatch.setattr(sys, "argv", args)
     cli.main()
-    assert captured.get('proxy') == 'socks5://localhost:9050'
+    assert captured.get("proxy") == "socks5://localhost:9050"
 
 
 def test_cli_proxy_error(monkeypatch, tmp_path):
     def fake_init(*a, **k):
-        raise ValueError('Proxy unreachable')
+        raise ValueError("Proxy unreachable")
 
-    monkeypatch.setattr(Scraper, '__init__', fake_init)
-    cache_folder = tmp_path / 'cache'
+    monkeypatch.setattr(Scraper, "__init__", fake_init)
+    cache_folder = tmp_path / "cache"
     args = [
-        'prog',
-        '--url',
-        'http://example.com',
-        '--output-folder',
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
         str(tmp_path),
-        '--cache-folder',
+        "--cache-folder",
         str(cache_folder),
-        '--proxy',
-        'http://proxy:8080',
+        "--proxy",
+        "http://proxy:8080",
     ]
-    monkeypatch.setattr(sys, 'argv', args)
+    monkeypatch.setattr(sys, "argv", args)
     with pytest.raises(SystemExit):
         cli.main()
 
@@ -229,6 +232,7 @@ def test_cli_include_exclude_options(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Fake initializer to capture include/exclude arguments.
@@ -237,32 +241,32 @@ def test_cli_include_exclude_options(monkeypatch, tmp_path):
             include_filters (list, optional): Selectors to include.
             exclude_filters (list, optional): Selectors to exclude.
         """
-        captured['include_filters'] = include_filters
-        captured['exclude_filters'] = exclude_filters
+        captured["include_filters"] = include_filters
+        captured["exclude_filters"] = exclude_filters
 
-    monkeypatch.setattr(Scraper, '__init__', fake_init)
-    monkeypatch.setattr(Scraper, 'start_scraping', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_markdown', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_json', lambda *a, **k: None)
+    monkeypatch.setattr(Scraper, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
 
-    cache_folder = tmp_path / 'cache'
+    cache_folder = tmp_path / "cache"
     args = [
-        'prog',
-        '--url',
-        'http://example.com',
-        '--output-folder',
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
         str(tmp_path),
-        '--cache-folder',
+        "--cache-folder",
         str(cache_folder),
-        '--include',
-        'p',
-        '--exclude',
-        '.remove',
+        "--include",
+        "p",
+        "--exclude",
+        ".remove",
     ]
-    monkeypatch.setattr(sys, 'argv', args)
+    monkeypatch.setattr(sys, "argv", args)
     cli.main()
-    assert captured.get('include_filters') == ['p']
-    assert captured.get('exclude_filters') == ['.remove']
+    assert captured.get("include_filters") == ["p"]
+    assert captured.get("exclude_filters") == [".remove"]
 
 
 def test_cli_include_exclude_short_options(monkeypatch, tmp_path):
@@ -286,6 +290,7 @@ def test_cli_include_exclude_short_options(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Capture include and exclude selectors from short options.
@@ -294,32 +299,32 @@ def test_cli_include_exclude_short_options(monkeypatch, tmp_path):
             include_filters (list, optional): Selectors to include.
             exclude_filters (list, optional): Selectors to exclude.
         """
-        captured['include_filters'] = include_filters
-        captured['exclude_filters'] = exclude_filters
+        captured["include_filters"] = include_filters
+        captured["exclude_filters"] = exclude_filters
 
-    monkeypatch.setattr(Scraper, '__init__', fake_init)
-    monkeypatch.setattr(Scraper, 'start_scraping', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_markdown', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_json', lambda *a, **k: None)
+    monkeypatch.setattr(Scraper, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
 
-    cache_folder = tmp_path / 'cache'
+    cache_folder = tmp_path / "cache"
     args = [
-        'prog',
-        '--url',
-        'http://example.com',
-        '--output-folder',
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
         str(tmp_path),
-        '--cache-folder',
+        "--cache-folder",
         str(cache_folder),
-        '-i',
-        '#keep',
-        '-x',
-        'span',
+        "-i",
+        "#keep",
+        "-x",
+        "span",
     ]
-    monkeypatch.setattr(sys, 'argv', args)
+    monkeypatch.setattr(sys, "argv", args)
     cli.main()
-    assert captured.get('include_filters') == ['#keep']
-    assert captured.get('exclude_filters') == ['span']
+    assert captured.get("include_filters") == ["#keep"]
+    assert captured.get("exclude_filters") == ["span"]
 
 
 def test_cli_include_url_option(monkeypatch, tmp_path):
@@ -343,6 +348,7 @@ def test_cli_include_url_option(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=None,
     ):
         """
         Capture include URL patterns argument.
@@ -350,92 +356,179 @@ def test_cli_include_url_option(monkeypatch, tmp_path):
         Args:
             include_url_patterns (list): URL substrings to include.
         """
-        captured['include_url_patterns'] = include_url_patterns
+        captured["include_url_patterns"] = include_url_patterns
 
-    monkeypatch.setattr(Scraper, '__init__', fake_init)
-    monkeypatch.setattr(Scraper, 'start_scraping', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_markdown', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_json', lambda *a, **k: None)
+    monkeypatch.setattr(Scraper, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
 
-    cache_folder = tmp_path / 'cache'
+    cache_folder = tmp_path / "cache"
     args = [
-        'prog',
-        '--url',
-        'http://example.com',
-        '--output-folder',
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
         str(tmp_path),
-        '--cache-folder',
+        "--cache-folder",
         str(cache_folder),
-        '--include-url',
-        '/blog',
+        "--include-url",
+        "/blog",
     ]
-    monkeypatch.setattr(sys, 'argv', args)
+    monkeypatch.setattr(sys, "argv", args)
     cli.main()
-    assert captured.get('include_url_patterns') == ['/blog']
+    assert captured.get("include_url_patterns") == ["/blog"]
 
 
 def test_cli_overwrite_cache(monkeypatch, tmp_path):
     captured = {}
 
     def fake_init(self, db_path):
-        captured['exists'] = os.path.exists(db_path)
-        self.conn = sqlite3.connect(':memory:')
+        captured["exists"] = os.path.exists(db_path)
+        self.conn = sqlite3.connect(":memory:")
 
-    monkeypatch.setattr(DatabaseManager, '__init__', fake_init)
-    monkeypatch.setattr(ExportManager, 'export_to_markdown', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_json', lambda *a, **k: None)
-    monkeypatch.setattr(Scraper, 'start_scraping', lambda *a, **k: None)
+    monkeypatch.setattr(DatabaseManager, "__init__", fake_init)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
 
-    cache_folder = tmp_path / 'cache'
-    db_name = utils.url_to_filename('http://example.com') + '.sqlite'
+    cache_folder = tmp_path / "cache"
+    db_name = utils.url_to_filename("http://example.com") + ".sqlite"
     db_path = cache_folder / db_name
     cache_folder.mkdir()
-    db_path.write_text('dummy')
+    db_path.write_text("dummy")
 
     args = [
-        'prog',
-        '--url',
-        'http://example.com',
-        '--output-folder',
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
         str(tmp_path),
-        '--cache-folder',
+        "--cache-folder",
         str(cache_folder),
-        '--overwrite-cache',
+        "--overwrite-cache",
     ]
-    monkeypatch.setattr(sys, 'argv', args)
+    monkeypatch.setattr(sys, "argv", args)
     cli.main()
-    assert captured.get('exists') is False
+    assert captured.get("exists") is False
 
 
 def test_cli_overwrite_cache_short_option(monkeypatch, tmp_path):
     captured = {}
 
     def fake_init(self, db_path):
-        captured['exists'] = os.path.exists(db_path)
-        self.conn = sqlite3.connect(':memory:')
+        captured["exists"] = os.path.exists(db_path)
+        self.conn = sqlite3.connect(":memory:")
 
-    monkeypatch.setattr(DatabaseManager, '__init__', fake_init)
-    monkeypatch.setattr(ExportManager, 'export_to_markdown', lambda *a, **k: None)
-    monkeypatch.setattr(ExportManager, 'export_to_json', lambda *a, **k: None)
-    monkeypatch.setattr(Scraper, 'start_scraping', lambda *a, **k: None)
+    monkeypatch.setattr(DatabaseManager, "__init__", fake_init)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
 
-    cache_folder = tmp_path / 'cache'
-    db_name = utils.url_to_filename('http://example.com') + '.sqlite'
+    cache_folder = tmp_path / "cache"
+    db_name = utils.url_to_filename("http://example.com") + ".sqlite"
     db_path = cache_folder / db_name
     cache_folder.mkdir()
-    db_path.write_text('dummy')
+    db_path.write_text("dummy")
 
     args = [
-        'prog',
-        '--url',
-        'http://example.com',
-        '--output-folder',
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
         str(tmp_path),
-        '--cache-folder',
+        "--cache-folder",
         str(cache_folder),
-        '-w',
+        "-w",
     ]
-    monkeypatch.setattr(sys, 'argv', args)
+    monkeypatch.setattr(sys, "argv", args)
     cli.main()
-    assert captured.get('exists') is False
+    assert captured.get("exists") is False
 
+
+def test_cli_timeout_option_passed_to_scraper(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_init(
+        self,
+        base_url,
+        exclude_patterns,
+        include_url_patterns,
+        db_manager,
+        rate_limit=0,
+        delay=0,
+        proxy=None,
+        include_filters=None,
+        exclude_filters=None,
+        timeout=None,
+    ):
+        captured["timeout"] = timeout
+
+    monkeypatch.setattr(Scraper, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
+
+    cache_folder = tmp_path / "cache"
+    args = [
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
+        str(tmp_path),
+        "--cache-folder",
+        str(cache_folder),
+        "--timeout",
+        "2.5",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    cli.main()
+    assert captured.get("timeout") == 2.5
+
+
+def test_cli_timeout_default_passed_to_scraper(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_init(
+        self,
+        base_url,
+        exclude_patterns,
+        include_url_patterns,
+        db_manager,
+        rate_limit=0,
+        delay=0,
+        proxy=None,
+        include_filters=None,
+        exclude_filters=None,
+        timeout=None,
+    ):
+        captured["timeout"] = timeout
+
+    monkeypatch.setattr(Scraper, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
+
+    cache_folder = tmp_path / "cache"
+    args = [
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
+        str(tmp_path),
+        "--cache-folder",
+        str(cache_folder),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    cli.main()
+    assert captured.get("timeout") == 10
+
+
+def test_cli_help_mentions_timeout(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["prog", "--help"])
+
+    with pytest.raises(SystemExit):
+        cli.main()
+
+    help_output = capsys.readouterr().out
+    assert "--timeout" in help_output

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -6,32 +6,55 @@ from crawler_to_md.database_manager import DatabaseManager
 
 def test_database_operations():
     with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = os.path.join(tmpdir, 'test.db')
+        db_path = os.path.join(tmpdir, "test.db")
         db = DatabaseManager(db_path)
 
         # Insert link and verify count
-        assert db.insert_link('http://example.com') is True
+        assert db.insert_link("http://example.com") is True
         assert db.get_links_count() == 1
-        assert db.get_unvisited_links() == [('http://example.com',)]
+        assert db.get_unvisited_links() == [("http://example.com",)]
 
         # Mark link visited
-        db.mark_link_visited('http://example.com')
+        db.mark_link_visited("http://example.com")
         assert db.get_visited_links_count() == 1
         assert db.get_unvisited_links() == []
 
         # Insert page and read back
-        db.insert_page('http://example.com', 'content', '{}')
+        db.insert_page("http://example.com", "content", "{}")
         pages = db.get_all_pages()
-        assert pages == [('http://example.com', 'content', '{}')]
+        assert pages == [("http://example.com", "content", "{}")]
 
 
 def test_insert_link_duplicates_and_list():
-    db = DatabaseManager(':memory:')
-    assert db.insert_link('http://a') is True
+    db = DatabaseManager(":memory:")
+    assert db.insert_link("http://a") is True
     # duplicate single link should return False
-    assert db.insert_link('http://a') is False
+    assert db.insert_link("http://a") is False
     # insert list with one new and one duplicate
-    assert db.insert_link(['http://b', 'http://a']) is True
+    assert db.insert_link(["http://b", "http://a"]) is True
     # total links should be 2
     assert db.get_links_count() == 2
-    assert set(db.get_unvisited_links()) == {('http://a',), ('http://b',)}
+    assert set(db.get_unvisited_links()) == {("http://a",), ("http://b",)}
+
+
+def test_upsert_page_replaces_existing_content():
+    db = DatabaseManager(":memory:")
+    db.insert_page("http://a", None, '{"scrape_status":"failed"}')
+
+    db.upsert_page("http://a", "# Title", '{"title":"A"}')
+
+    assert db.get_all_pages() == [("http://a", "# Title", '{"title":"A"}')]
+
+
+def test_get_failed_page_urls_and_mark_unvisited():
+    db = DatabaseManager(":memory:")
+    db.insert_link("http://a", visited=True)
+    db.insert_link("http://b", visited=True)
+    db.insert_page("http://a", None, '{"scrape_status":"failed"}')
+    db.insert_page("http://b", "# ok", '{"title":"ok"}')
+
+    assert db.get_failed_page_urls() == ["http://a"]
+
+    db.mark_link_unvisited("http://a")
+
+    assert db.get_unvisited_links() == [("http://a",)]

--- a/tests/test_export_manager.py
+++ b/tests/test_export_manager.py
@@ -7,12 +7,12 @@ from crawler_to_md.export_manager import ExportManager
 
 
 def create_populated_db(tmpdir):
-    db_path = os.path.join(tmpdir, 'db.sqlite')
+    db_path = os.path.join(tmpdir, "db.sqlite")
     db = DatabaseManager(db_path)
-    db.insert_link('http://example.com')
-    db.mark_link_visited('http://example.com')
+    db.insert_link("http://example.com")
+    db.mark_link_visited("http://example.com")
     db.insert_page(
-        'http://example.com', '# Title\nParagraph', json.dumps({'author': 'John'})
+        "http://example.com", "# Title\nParagraph", json.dumps({"author": "John"})
     )
     return db
 
@@ -20,9 +20,9 @@ def create_populated_db(tmpdir):
 def test_export_markdown_and_json():
     with tempfile.TemporaryDirectory() as tmpdir:
         db = create_populated_db(tmpdir)
-        exporter = ExportManager(db, title='My Title')
-        md_path = os.path.join(tmpdir, 'out.md')
-        json_path = os.path.join(tmpdir, 'out.json')
+        exporter = ExportManager(db, title="My Title")
+        md_path = os.path.join(tmpdir, "out.md")
+        json_path = os.path.join(tmpdir, "out.json")
 
         exporter.export_to_markdown(md_path)
         exporter.export_to_json(json_path)
@@ -30,79 +30,108 @@ def test_export_markdown_and_json():
         assert os.path.exists(md_path)
         assert os.path.exists(json_path)
 
-        with open(md_path, 'r', encoding='utf-8') as f:
+        with open(md_path, "r", encoding="utf-8") as f:
             content = f.read()
-            assert content.startswith('# My Title')
-            assert '## Title' in content
-            assert 'URL: http://example.com' in content
+            assert content.startswith("# My Title")
+            assert "## Title" in content
+            assert "URL: http://example.com" in content
 
-        with open(json_path, 'r', encoding='utf-8') as f:
+        with open(json_path, "r", encoding="utf-8") as f:
             data = json.load(f)
-            assert data[0]['url'] == 'http://example.com'
-            assert 'Title' in data[0]['content']
-            assert data[0]['metadata']['author'] == 'John'
+            assert data[0]["url"] == "http://example.com"
+            assert "Title" in data[0]["content"]
+            assert data[0]["metadata"]["author"] == "John"
 
 
 def test_adjust_headers_and_cleanup():
-    db = DatabaseManager(':memory:')
-    exporter = ExportManager(db, title='T')
-    content = '# H1\n## H2'
+    db = DatabaseManager(":memory:")
+    exporter = ExportManager(db, title="T")
+    content = "# H1\n## H2"
     adjusted = exporter._adjust_headers(content, level_increment=1)
-    assert '## H1' in adjusted
-    assert '### H2' in adjusted
-    cleaned = exporter._cleanup_markdown('A\n\n\nB')
-    assert cleaned == 'A\n\nB'
+    assert "## H1" in adjusted
+    assert "### H2" in adjusted
+    cleaned = exporter._cleanup_markdown("A\n\n\nB")
+    assert cleaned == "A\n\nB"
 
 
 def test_concatenate_markdown_filters_metadata():
-    db = DatabaseManager(':memory:')
-    db.insert_page('http://a', '# T1', json.dumps({'keep': 'x'}))
-    db.insert_page('http://b', '# T2', json.dumps({'drop': None}))
-    exporter = ExportManager(db, title='Head')
+    db = DatabaseManager(":memory:")
+    db.insert_page("http://a", "# T1", json.dumps({"keep": "x"}))
+    db.insert_page("http://b", "# T2", json.dumps({"drop": None}))
+    exporter = ExportManager(db, title="Head")
     result = exporter._concatenate_markdown(db.get_all_pages())
-    assert result.startswith('# Head')
-    assert 'URL: http://a' in result and 'T1' in result
-    assert 'keep: x' in result
-    assert 'drop:' not in result
+    assert result.startswith("# Head")
+    assert "URL: http://a" in result and "T1" in result
+    assert "keep: x" in result
+    assert "drop:" not in result
 
 
 def test_export_individual_markdown(tmp_path):
-    db_path = tmp_path / 'db.sqlite'
+    db_path = tmp_path / "db.sqlite"
     db = DatabaseManager(str(db_path))
-    db.insert_page('http://example.com/path/page', '# P', '{}')
+    db.insert_page("http://example.com/path/page", "# P", "{}")
     exporter = ExportManager(db)
     output_folder = exporter.export_individual_markdown(str(tmp_path))
-    expected = tmp_path / 'files' / 'example.com' / 'path' / 'page.md'
+    expected = tmp_path / "files" / "example.com" / "path" / "page.md"
     assert expected.exists()
-    assert output_folder == str(tmp_path / 'files')
+    assert output_folder == str(tmp_path / "files")
 
 
 def test_adjust_headers_upper_limit():
-    db = DatabaseManager(':memory:')
+    db = DatabaseManager(":memory:")
     exporter = ExportManager(db)
-    content = '###### H6\n####### H7'
+    content = "###### H6\n####### H7"
     adjusted = exporter._adjust_headers(content, level_increment=1)
-    lines = [line for line in adjusted.split('\n') if line.startswith('#')]
+    lines = [line for line in adjusted.split("\n") if line.startswith("#")]
     # both lines should not exceed 6 hashes
     assert all(len(line.split()[0]) <= 6 for line in lines)
 
 
 def test_concatenate_skips_none_content():
-    db = DatabaseManager(':memory:')
-    db.insert_page('http://a', None, '{}')
-    db.insert_page('http://b', '# T', '{}')
-    exporter = ExportManager(db, title='Top')
+    db = DatabaseManager(":memory:")
+    db.insert_page("http://a", None, "{}")
+    db.insert_page("http://b", "# T", "{}")
+    exporter = ExportManager(db, title="Top")
     content = exporter._concatenate_markdown(db.get_all_pages())
-    assert 'URL: http://a' not in content
-    assert 'URL: http://b' in content
+    assert "URL: http://a" not in content
+    assert "URL: http://b" in content
 
 
 def test_export_to_json_skips_none(tmp_path):
-    db = DatabaseManager(':memory:')
-    db.insert_page('http://a', None, '{}')
-    db.insert_page('http://b', '# T', '{}')
+    db = DatabaseManager(":memory:")
+    db.insert_page("http://a", None, "{}")
+    db.insert_page("http://b", "# T", "{}")
     exporter = ExportManager(db)
-    json_path = tmp_path / 'out.json'
+    json_path = tmp_path / "out.json"
     exporter.export_to_json(str(json_path))
-    data = json.load(open(json_path, 'r', encoding='utf-8'))
-    assert len(data) == 1 and data[0]['url'] == 'http://b'
+    data = json.load(open(json_path, "r", encoding="utf-8"))
+    assert len(data) == 1 and data[0]["url"] == "http://b"
+
+
+def test_export_handles_legacy_null_metadata(tmp_path):
+    db = DatabaseManager(":memory:")
+    db.insert_page("http://a", "# A", "null")
+    exporter = ExportManager(db, title="Head")
+
+    md_path = tmp_path / "out.md"
+    json_path = tmp_path / "out.json"
+
+    exporter.export_to_markdown(str(md_path))
+    exporter.export_to_json(str(json_path))
+
+    data = json.load(open(json_path, "r", encoding="utf-8"))
+    assert data[0]["url"] == "http://a"
+    assert data[0]["metadata"] == {}
+
+
+def test_export_individual_skips_none_content(tmp_path):
+    db = DatabaseManager(":memory:")
+    db.insert_page("http://example.com/a", None, '{"scrape_status":"failed"}')
+    db.insert_page("http://example.com/b", "# B", "{}")
+    exporter = ExportManager(db)
+
+    output_folder = exporter.export_individual_markdown(str(tmp_path))
+
+    assert not (tmp_path / "files" / "example.com" / "a.md").exists()
+    assert (tmp_path / "files" / "example.com" / "b.md").exists()
+    assert output_folder == str(tmp_path / "files")

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -24,67 +24,74 @@ class DummyDB(DatabaseManager):
     def mark_link_visited(self, url):
         pass
 
+    def mark_link_unvisited(self, url):
+        pass
+
+    def get_failed_page_urls(self):
+        return []
+
+    def upsert_page(self, url, content, metadata):
+        pass
+
 
 def test_is_valid_link():
     db = DummyDB()
     scraper = Scraper(
-        base_url='https://example.com',
-        exclude_patterns=['/exclude'],
+        base_url="https://example.com",
+        exclude_patterns=["/exclude"],
         include_url_patterns=[],
         db_manager=db,
     )
-    assert scraper.is_valid_link('https://example.com/page')
-    assert not scraper.is_valid_link('https://example.com/exclude/page')
-    assert not scraper.is_valid_link('https://other.com/')
+    assert scraper.is_valid_link("https://example.com/page")
+    assert not scraper.is_valid_link("https://example.com/exclude/page")
+    assert not scraper.is_valid_link("https://other.com/")
 
     include_scraper = Scraper(
-        base_url='https://example.com',
+        base_url="https://example.com",
         exclude_patterns=[],
-        include_url_patterns=['/docs'],
+        include_url_patterns=["/docs"],
         db_manager=db,
     )
-    assert include_scraper.is_valid_link('https://example.com/docs/page')
-    assert not include_scraper.is_valid_link('https://example.com/blog')
+    assert include_scraper.is_valid_link("https://example.com/docs/page")
+    assert not include_scraper.is_valid_link("https://example.com/blog")
 
 
 def test_fetch_links():
     db = DummyDB()
     scraper = Scraper(
-        base_url='https://example.com',
-        exclude_patterns=['/exclude'],
+        base_url="https://example.com",
+        exclude_patterns=["/exclude"],
         include_url_patterns=[],
         db_manager=db,
     )
-    html = '''<html><body>
+    html = """<html><body>
     <a href="https://example.com/page1">1</a>
     <a href="/page2">2</a>
     <a href="https://example.com/exclude/hidden">3</a>
-    </body></html>'''
-    links = scraper.fetch_links(url='https://example.com', html=html)
-    assert links == {'https://example.com/page1', 'https://example.com/page2'}
+    </body></html>"""
+    links = scraper.fetch_links(url="https://example.com", html=html)
+    assert links == {"https://example.com/page1", "https://example.com/page2"}
 
 
 def test_fetch_links_includes_only_matching_patterns():
     db = DummyDB()
     scraper = Scraper(
-        base_url='https://example.com',
+        base_url="https://example.com",
         exclude_patterns=[],
-        include_url_patterns=['/page1'],
+        include_url_patterns=["/page1"],
         db_manager=db,
     )
-    html = '''<html><body>
+    html = """<html><body>
     <a href="https://example.com/page1">1</a>
     <a href="/page2">2</a>
     <a href="https://example.com/page3">3</a>
-    </body></html>'''
-    links = scraper.fetch_links(url='https://example.com', html=html)
-    assert links == {'https://example.com/page1'}
+    </body></html>"""
+    links = scraper.fetch_links(url="https://example.com", html=html)
+    assert links == {"https://example.com/page1"}
 
 
-
-
-@patch('os.remove')
-@patch('tempfile.NamedTemporaryFile')
+@patch("os.remove")
+@patch("tempfile.NamedTemporaryFile")
 def test_scrape_page_parses_content_and_metadata(mock_tempfile, mock_os_remove):
     # Arrange
     mock_file = MagicMock()
@@ -93,26 +100,27 @@ def test_scrape_page_parses_content_and_metadata(mock_tempfile, mock_os_remove):
 
     db = DummyDB()
     scraper = Scraper(
-        base_url='http://example.com',
+        base_url="http://example.com",
         exclude_patterns=[],
         include_url_patterns=[],
         db_manager=db,
     )
-    html = '<html><head><title>Test</title></head><body><p>Hello</p></body></html>'
+    html = "<html><head><title>Test</title></head><body><p>Hello</p></body></html>"
 
     # Act
-    with patch('crawler_to_md.scraper.MarkItDown') as mock_markdown:
+    with patch("crawler_to_md.scraper.MarkItDown") as mock_markdown:
         mock_markdown.return_value.convert.return_value = "Hello"
-        content, metadata = scraper.scrape_page(html, 'http://example.com/test')
+        content, metadata = scraper.scrape_page(html, "http://example.com/test")
 
     # Assert
     assert content is not None
-    assert 'Hello' in content
+    assert "Hello" in content
     assert metadata is not None
-    assert metadata.get('title') == 'Test'
+    assert metadata.get("title") == "Test"
 
-@patch('os.remove')
-@patch('tempfile.NamedTemporaryFile')
+
+@patch("os.remove")
+@patch("tempfile.NamedTemporaryFile")
 def test_scrape_page_with_markitdown(mock_tempfile, mock_os_remove):
     # Arrange
     mock_file = MagicMock()
@@ -121,32 +129,32 @@ def test_scrape_page_with_markitdown(mock_tempfile, mock_os_remove):
 
     db = DummyDB()
     scraper = Scraper(
-        base_url='http://example.com',
+        base_url="http://example.com",
         exclude_patterns=[],
         include_url_patterns=[],
         db_manager=db,
     )
     html = (
-        '<html><head><title>Test</title></head><body><h1>A Title</h1>'
-        '<p>This is a paragraph with <strong>bold</strong> text.</p></body></html>'
+        "<html><head><title>Test</title></head><body><h1>A Title</h1>"
+        "<p>This is a paragraph with <strong>bold</strong> text.</p></body></html>"
     )
 
     # Act
-    with patch('crawler_to_md.scraper.MarkItDown') as mock_markdown:
+    with patch("crawler_to_md.scraper.MarkItDown") as mock_markdown:
         mock_markdown.return_value.convert.return_value = (
             "# A Title\n\nThis is a paragraph with **bold** text."
         )
-        content, metadata = scraper.scrape_page(html, 'http://example.com/test')
+        content, metadata = scraper.scrape_page(html, "http://example.com/test")
 
     # Assert
     assert content is not None
-    assert content == '# A Title\n\nThis is a paragraph with **bold** text.'
+    assert content == "# A Title\n\nThis is a paragraph with **bold** text."
     assert metadata is not None
-    assert metadata.get('title') == 'Test'
+    assert metadata.get("title") == "Test"
 
 
-@patch('os.remove')
-@patch('tempfile.NamedTemporaryFile')
+@patch("os.remove")
+@patch("tempfile.NamedTemporaryFile")
 def test_scrape_page_include_exclude(mock_tempfile, mock_os_remove):
     """
     Verify include and exclude selectors filter HTML before conversion.
@@ -161,31 +169,31 @@ def test_scrape_page_include_exclude(mock_tempfile, mock_os_remove):
 
     db = DummyDB()
     scraper = Scraper(
-        base_url='http://example.com',
+        base_url="http://example.com",
         exclude_patterns=[],
         include_url_patterns=[],
         db_manager=db,
-        include_filters=['p'],
-        exclude_filters=['.remove'],
+        include_filters=["p"],
+        exclude_filters=[".remove"],
     )
     html = (
         '<html><body><p class="keep">Keep</p>'
         '<p class="remove">Remove</p><span>Ignore</span></body></html>'
     )
 
-    with patch('crawler_to_md.scraper.MarkItDown') as mock_markdown:
+    with patch("crawler_to_md.scraper.MarkItDown") as mock_markdown:
+
         def convert_side_effect(path):
             """Return the HTML written to the temporary file."""
             return mock_file.write.call_args[0][0]
 
         mock_markdown.return_value.convert.side_effect = convert_side_effect
-        content, metadata = scraper.scrape_page(html, 'http://example.com/test')
+        content, metadata = scraper.scrape_page(html, "http://example.com/test")
 
-    assert 'Keep' in content
-    assert 'Remove' not in content
-    assert 'Ignore' not in content
-    assert metadata.get('title') == ''
-
+    assert "Keep" in content
+    assert "Remove" not in content
+    assert "Ignore" not in content
+    assert metadata.get("title") == ""
 
 
 class ListDB(DummyDB):
@@ -209,6 +217,10 @@ class ListDB(DummyDB):
     def mark_link_visited(self, url):
         self.visited.add(url)
 
+    def mark_link_unvisited(self, url):
+        if url in self.visited:
+            self.visited.remove(url)
+
     def get_links_count(self):
         return len(self.links)
 
@@ -218,6 +230,16 @@ class ListDB(DummyDB):
     def insert_page(self, url, content, metadata):
         self.pages.append((url, content, metadata))
 
+    def upsert_page(self, url, content, metadata):
+        for index, existing in enumerate(self.pages):
+            if existing[0] == url:
+                self.pages[index] = (url, content, metadata)
+                return
+        self.pages.append((url, content, metadata))
+
+    def get_failed_page_urls(self):
+        return [url for url, content, _ in self.pages if content is None]
+
     def get_all_pages(self):
         return self.pages
 
@@ -225,102 +247,106 @@ class ListDB(DummyDB):
 def test_start_scraping_process(monkeypatch):
     db = ListDB()
     scraper = Scraper(
-        base_url='http://example.com',
+        base_url="http://example.com",
         exclude_patterns=[],
         include_url_patterns=[],
         db_manager=db,
     )
 
-    monkeypatch.setattr(Scraper, 'fetch_links', lambda self, url, html=None: set())
+    monkeypatch.setattr(Scraper, "fetch_links", lambda self, url, html=None: set())
     monkeypatch.setattr(
-        Scraper, 'scrape_page', lambda self, html, url: ('# MD', {'url': url})
+        Scraper, "scrape_page", lambda self, html, url: ("# MD", {"url": url})
     )
 
     class DummyResp:
         status_code = 200
-        headers = {'content-type': 'text/html'}
-        content = b'<html></html>'
-        text = '<html></html>'
+        headers = {"content-type": "text/html"}
+        content = b"<html></html>"
+        text = "<html></html>"
 
-    monkeypatch.setattr(scraper.session, 'get', lambda url: DummyResp())
+    monkeypatch.setattr(scraper.session, "get", lambda url: DummyResp())
 
     class DummyTqdm:
         def __init__(self, *a, **k):
-            self.total = k.get('total', 0)
+            self.total = k.get("total", 0)
+
         def update(self, n):
             pass
+
         def refresh(self):
             pass
+
         def close(self):
             pass
 
-    monkeypatch.setattr(tqdm, 'tqdm', lambda *a, **k: DummyTqdm(*a, **k))
+    monkeypatch.setattr(tqdm, "tqdm", lambda *a, **k: DummyTqdm(*a, **k))
 
-    scraper.start_scraping(url='http://example.com/page')
+    scraper.start_scraping(url="http://example.com/page")
 
     assert db.get_links_count() == 1
     assert db.get_visited_links_count() == 1
-    assert db.pages[0][0] == 'http://example.com/page'
+    assert db.pages[0][0] == "http://example.com/page"
 
 
 def test_scraper_proxy_initialization(monkeypatch):
     db = DummyDB()
-    monkeypatch.setattr(Scraper, '_test_proxy', lambda self: None)
+    monkeypatch.setattr(Scraper, "_test_proxy", lambda self: None)
     scraper = Scraper(
-        base_url='http://example.com',
+        base_url="http://example.com",
         exclude_patterns=[],
         include_url_patterns=[],
         db_manager=db,
-        proxy='http://proxy:8080'
+        proxy="http://proxy:8080",
     )
-    assert scraper.session.proxies.get('http') == 'http://proxy:8080'
-    assert scraper.session.proxies.get('https') == 'http://proxy:8080'
+    assert scraper.session.proxies.get("http") == "http://proxy:8080"
+    assert scraper.session.proxies.get("https") == "http://proxy:8080"
 
 
 def test_scraper_socks_proxy_initialization(monkeypatch):
     db = DummyDB()
-    proxy = 'socks5://localhost:9050'
-    monkeypatch.setattr(Scraper, '_test_proxy', lambda self: None)
+    proxy = "socks5://localhost:9050"
+    monkeypatch.setattr(Scraper, "_test_proxy", lambda self: None)
     scraper = Scraper(
-        base_url='http://example.com',
+        base_url="http://example.com",
         exclude_patterns=[],
         include_url_patterns=[],
         db_manager=db,
-        proxy=proxy
+        proxy=proxy,
     )
-    assert scraper.session.proxies.get('http') == proxy
-    assert scraper.session.proxies.get('https') == proxy
+    assert scraper.session.proxies.get("http") == proxy
+    assert scraper.session.proxies.get("https") == proxy
 
 
 def test_scraper_proxy_failure_detection(monkeypatch):
     db = DummyDB()
+
     def fake_head(self, url, timeout=5):
         raise requests.exceptions.ProxyError("fail")
 
-    monkeypatch.setattr(requests.Session, 'head', fake_head)
+    monkeypatch.setattr(requests.Session, "head", fake_head)
     with pytest.raises(ValueError):
         Scraper(
-            base_url='http://example.com',
+            base_url="http://example.com",
             exclude_patterns=[],
             include_url_patterns=[],
             db_manager=db,
-            proxy='http://proxy:8080'
+            proxy="http://proxy:8080",
         )
 
 
 def test_scrape_page_returns_none_for_empty_content(monkeypatch):
     db = DummyDB()
     scraper = Scraper(
-        base_url='http://example.com',
+        base_url="http://example.com",
         exclude_patterns=[],
         include_url_patterns=[],
         db_manager=db,
     )
-    html = '<html><body></body></html>'
+    html = "<html><body></body></html>"
 
-    with patch('crawler_to_md.scraper.MarkItDown') as mock_markdown:
-        mock_markdown.return_value.convert.return_value = ''
-        content, metadata = scraper.scrape_page(html, 'http://example.com/empty')
+    with patch("crawler_to_md.scraper.MarkItDown") as mock_markdown:
+        mock_markdown.return_value.convert.return_value = ""
+        content, metadata = scraper.scrape_page(html, "http://example.com/empty")
 
     assert content is None
     assert metadata is None
@@ -329,88 +355,198 @@ def test_scrape_page_returns_none_for_empty_content(monkeypatch):
 def test_start_scraping_excludes_invalid_urls(monkeypatch):
     db = ListDB()
     scraper = Scraper(
-        base_url='http://example.com',
-        exclude_patterns=['/exclude'],
+        base_url="http://example.com",
+        exclude_patterns=["/exclude"],
         include_url_patterns=[],
         db_manager=db,
     )
 
-    monkeypatch.setattr(Scraper, 'fetch_links', lambda self, url, html=None: set())
+    monkeypatch.setattr(Scraper, "fetch_links", lambda self, url, html=None: set())
     monkeypatch.setattr(
-        Scraper, 'scrape_page', lambda self, html, url: ('# MD', {'url': url})
+        Scraper, "scrape_page", lambda self, html, url: ("# MD", {"url": url})
     )
 
     class DummyResp:
         status_code = 200
-        headers = {'content-type': 'text/html'}
-        content = b'<html></html>'
-        text = '<html></html>'
+        headers = {"content-type": "text/html"}
+        content = b"<html></html>"
+        text = "<html></html>"
 
-    monkeypatch.setattr(scraper.session, 'get', lambda url: DummyResp())
+    monkeypatch.setattr(scraper.session, "get", lambda url: DummyResp())
 
     class DummyTqdm:
         def __init__(self, *a, **k):
-            self.total = k.get('total', 0)
+            self.total = k.get("total", 0)
+
         def update(self, n):
             pass
+
         def refresh(self):
             pass
+
         def close(self):
             pass
 
-    monkeypatch.setattr(tqdm, 'tqdm', lambda *a, **k: DummyTqdm(*a, **k))
+    monkeypatch.setattr(tqdm, "tqdm", lambda *a, **k: DummyTqdm(*a, **k))
 
     urls = [
-        'http://example.com/page1',
-        'http://example.com/exclude/page',
-        'http://example.com/page2',
+        "http://example.com/page1",
+        "http://example.com/exclude/page",
+        "http://example.com/page2",
     ]
 
     scraper.start_scraping(urls_list=urls)
 
-    assert 'http://example.com/exclude/page' not in db.links
+    assert "http://example.com/exclude/page" not in db.links
 
 
 def test_start_scraping_filters_discovered_links(monkeypatch):
     db = ListDB()
     scraper = Scraper(
-        base_url='http://example.com',
-        exclude_patterns=['/exclude'],
+        base_url="http://example.com",
+        exclude_patterns=["/exclude"],
         include_url_patterns=[],
         db_manager=db,
     )
 
     html = (
-        '<html><body>'
+        "<html><body>"
         '<a href="/page1">1</a>'
         '<a href="/exclude/page">2</a>'
         '<a href="/page2">3</a>'
-        '</body></html>'
+        "</body></html>"
     )
 
     class DummyResp:
         status_code = 200
-        headers = {'content-type': 'text/html'}
+        headers = {"content-type": "text/html"}
         text = html
 
-    monkeypatch.setattr(scraper.session, 'get', lambda url: DummyResp())
+    monkeypatch.setattr(scraper.session, "get", lambda url: DummyResp())
 
     monkeypatch.setattr(
-        Scraper, 'scrape_page', lambda self, html, url: ('# MD', {'url': url})
+        Scraper, "scrape_page", lambda self, html, url: ("# MD", {"url": url})
     )
 
     class DummyTqdm:
         def __init__(self, *a, **k):
-            self.total = k.get('total', 0)
+            self.total = k.get("total", 0)
+
         def update(self, n):
             pass
+
         def refresh(self):
             pass
+
         def close(self):
             pass
 
-    monkeypatch.setattr(tqdm, 'tqdm', lambda *a, **k: DummyTqdm(*a, **k))
+    monkeypatch.setattr(tqdm, "tqdm", lambda *a, **k: DummyTqdm(*a, **k))
 
-    scraper.start_scraping(url='http://example.com')
+    scraper.start_scraping(url="http://example.com")
 
-    assert 'http://example.com/exclude/page' not in db.links
+    assert "http://example.com/exclude/page" not in db.links
+
+
+def test_start_scraping_continues_after_request_exception(monkeypatch):
+    db = ListDB()
+    scraper = Scraper(
+        base_url="http://example.com",
+        exclude_patterns=[],
+        include_url_patterns=[],
+        db_manager=db,
+    )
+
+    monkeypatch.setattr(Scraper, "fetch_links", lambda self, url, html=None: set())
+    monkeypatch.setattr(
+        Scraper, "scrape_page", lambda self, html, url: ("# MD", {"url": url})
+    )
+
+    class DummyResp:
+        status_code = 200
+        headers = {"content-type": "text/html"}
+        text = "<html></html>"
+
+    def fake_get(url):
+        if url == "http://example.com/fail":
+            raise requests.RequestException("network error")
+        return DummyResp()
+
+    monkeypatch.setattr(scraper.session, "get", fake_get)
+
+    class DummyTqdm:
+        def __init__(self, *a, **k):
+            self.total = k.get("total", 0)
+
+        def update(self, n):
+            pass
+
+        def refresh(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(tqdm, "tqdm", lambda *a, **k: DummyTqdm(*a, **k))
+
+    scraper.start_scraping(
+        urls_list=["http://example.com/fail", "http://example.com/ok"]
+    )
+
+    assert db.get_visited_links_count() == 2
+    assert len(db.pages) == 2
+    assert any(page[0] == "http://example.com/ok" for page in db.pages)
+    assert any(
+        page[0] == "http://example.com/fail" and page[1] is None for page in db.pages
+    )
+
+
+def test_start_scraping_auto_retries_failed_pages(monkeypatch):
+    db = ListDB()
+    db.insert_link("http://example.com/retry")
+    db.mark_link_visited("http://example.com/retry")
+    db.upsert_page(
+        "http://example.com/retry",
+        None,
+        '{"scrape_status": "failed"}',
+    )
+
+    scraper = Scraper(
+        base_url="http://example.com",
+        exclude_patterns=[],
+        include_url_patterns=[],
+        db_manager=db,
+    )
+
+    monkeypatch.setattr(Scraper, "fetch_links", lambda self, url, html=None: set())
+    monkeypatch.setattr(
+        Scraper, "scrape_page", lambda self, html, url: ("# OK", {"title": "Retried"})
+    )
+
+    class DummyResp:
+        status_code = 200
+        headers = {"content-type": "text/html"}
+        text = "<html></html>"
+
+    monkeypatch.setattr(scraper.session, "get", lambda url: DummyResp())
+
+    class DummyTqdm:
+        def __init__(self, *a, **k):
+            self.total = k.get("total", 0)
+
+        def update(self, n):
+            pass
+
+        def refresh(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(tqdm, "tqdm", lambda *a, **k: DummyTqdm(*a, **k))
+
+    scraper.start_scraping()
+
+    assert len(db.pages) == 1
+    assert db.pages[0][0] == "http://example.com/retry"
+    assert db.pages[0][1] == "# OK"


### PR DESCRIPTION
## Why
- Improve crawl reliability across reruns by persisting and retrying failed pages.
- Provide compact markdown output for AI ingestion and content backup workflows.
- Make CLI usage more ergonomic and docs more accurate.

## Summary
- Add DB support for page upsert and failed-page retry primitives.
- Persist failed pages in scraper and retry them in subsequent runs.
- Add configurable request timeout in CLI/scraper integration.
- Harden export behavior for null metadata and empty individual pages.
- Add `--minify/-m` opt-in markdown minification for `.md` outputs.
- Add CLI aliases: `--output-dir` and `--cache-dir`.
- Update README and AGENTS docs; expand test coverage for new behavior.

## Minify Mode
- Preserves fenced code blocks exactly.
- Outside fences: removes blank lines, HTML comments, and hyphen-only separator lines; trims trailing whitespace except hard-break double spaces.
- Designed for AI ingestion/content backup, not rendering fidelity.

## Validation
- `ruff check .`
- `pytest`