### PR TITLE
Fix 403 errors on CDN-protected sites and auto-recover broken cache states                                                                                

### DIFF
--- a/crawler_to_md/database_manager.py
+++ b/crawler_to_md/database_manager.py
@@ -130,6 +130,25 @@ class DatabaseManager:
             )
             return cursor.fetchone()[0]
 
+    def reset_if_no_content(self, url):
+        """
+        Reset a link's visited status to False if it has no corresponding page content.
+        This recovers from broken cache states where a URL was marked visited
+        but was never successfully scraped.
+
+        Args:
+        url (str): The URL of the link to check and potentially reset.
+        """
+        with self.conn:
+            self.conn.execute(
+                """UPDATE links SET visited = FALSE
+                   WHERE url = ? AND NOT EXISTS (
+                       SELECT 1 FROM pages WHERE pages.url = ? AND pages.content IS NOT NULL
+                   )""",
+                (url, url),
+            )
+
+
     def get_all_pages(self):
         """
         Retrieve all pages from the 'pages' table.

--- a/crawler_to_md/scraper.py
+++ b/crawler_to_md/scraper.py
@@ -57,6 +57,15 @@ class Scraper:
         self.rate_limit = rate_limit
         self.delay = delay
         self.session = requests.Session()
+        self.session.headers.update({
+            "Accept-Encoding": "identity",
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0.0.0 Safari/537.36"
+            ),
+            "Referer": base_url or "",
+        })
         if proxy:
             self.session.proxies.update({"http": proxy, "https": proxy})
         self.proxy = proxy
@@ -268,6 +277,9 @@ class Scraper:
             # Insert the validated list of URLs into the database
             self.db_manager.insert_link(validated_urls)
         elif url:
+            # Reset the starting URL to unvisited if it was previously visited
+            # but produced no page content (recovers from broken cache states).
+            self.db_manager.reset_if_no_content(url)
             # Insert a single URL if provided and valid
             self.db_manager.insert_link(url)
 


### PR DESCRIPTION

**Problem 1: 403 Forbidden on child pages**

Some sites (particularly those behind CDN/WAF providers like WPX Cloud, LiteSpeed, Cloudflare) block requests that lack standard browser headers. The scraper was sending requests with no `User-Agent` and no `Referer`, causing the homepage to return `200` while all child pages returned `403` — resulting in a crawl of only 1 page.

**Fix:** Set a realistic `User-Agent` and `Referer` (base URL) on the session at initialization.

**Problem 2: Broken cache state causes silent re-run failures**

If a scraping run was interrupted or failed after a URL was marked `visited` but before its page content was stored, re-running the scraper would silently exit with no output. The progress bar would show `1/1` complete, but the exported files would be empty. There was no way to detect or recover from this without manually deleting the `.sqlite` cache file.

**Fix:** Added `reset_if_no_content(url)` to `DatabaseManager`, called on the starting URL before the crawl loop. It resets `visited = FALSE` for any URL that has no corresponding page content, allowing the scraper to automatically recover on the next run without user intervention and without affecting successfully scraped pages.

**Files changed:**
- `crawler_to_md/scraper.py` — browser headers on session init; call `reset_if_no_content` on start
- `crawler_to_md/database_manager.py` — new `reset_if_no_content(url)` method
