### PR TITLE
feat: dream roadmap — robustness, async, crawl intelligence, AI-ready outputs, plugins, MCP

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+# Restrict the default GITHUB_TOKEN to read-only for the whole workflow
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Lint and test (Python ${{ matrix.python-version }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Lint and test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Lint with ruff
+        run: uv run --extra dev ruff check .
+
+      - name: Run tests
+        run: uv run --extra dev pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,27 @@
-/old
-/old2
-/.venv
-/.history
+# Dead weight / legacy
+old/
+old2/
+.history/
+
+# Editor / IDE
 /.vscode
-/cache
-/output
-__pycache__
 .cursorignore
-/test.py
-.aider*
+
+# Python
+__pycache__/
+*.pyc
 *.egg-info
 .pytest_cache
 .ruff_cache
+.venv/
+
+# Tooling / caches
+.codegraph/
+.aider*
+
+# Runtime artifacts
+cache/
+output/
+*.sqlite
+.DS_Store
+/test.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Grégoire Compagnon (obeone)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -34,50 +34,229 @@ crawler-to-md --url https://www.example.com
 - Exports data to Markdown and JSON, ready for GPT uploads. 📤
 - Exports each page as an individual Markdown file if `--export-individual` is used. 📝
 - Uses SQLite for efficient data management. 📊
-- Configurable via command-line arguments. ⚙️
+- Configurable via command-line arguments or a `crawler-to-md.toml` config file. ⚙️
 - Include or exclude specific HTML elements using CSS-like selectors (#id, .class, tag) during Markdown conversion. 🧩
+- **Robustness**: automatic retries with exponential backoff, configurable timeouts, crawl bounds. 🔁
+- **Concurrency**: async `httpx` engine for parallel fetching (`--concurrency N`). ⚡
+- **Crawl intelligence**: robots.txt compliance, sitemap seeding, boilerplate extraction, JS rendering. 🧠
+- **AI-ready outputs**: JSONL, llms.txt/llms-full.txt, YAML frontmatter, RAG chunks, Parquet vectors. 🤖
+- **MCP server**: expose crawl tools to AI agents via the Model Context Protocol. 🔌
+- **Library API**: use `from crawler_to_md import crawl` in your own code. 📦
+- **Plugin system**: extend formatters, filters, processors, and fetchers via Python entry points. 🔧
 - Docker support. 🐳
 
 ## 📋 Requirements
 
 Python 3.10 or higher is required.
 
-Project dependencies are managed with `pyproject.toml`. Install them with:
+Project dependencies are managed with `pyproject.toml`. Install the core package with:
 
 ```shell
-pip install .
+pip install crawler-to-md
+```
+
+### Optional extras
+
+Heavy or niche features ship as optional extras so the core stays lightweight:
+
+| Extra | Install | Enables |
+|---|---|---|
+| `readability` | `pip install crawler-to-md[readability]` | Boilerplate extraction via trafilatura (`--extract readability`) |
+| `render` | `pip install crawler-to-md[render]` | JS rendering via Playwright (`--render`). After install run `playwright install chromium`. |
+| `rag` | `pip install crawler-to-md[rag]` | Token-aware RAG chunking via tiktoken (`--chunk-size`/`--chunk-overlap`); exact token counts in the run summary |
+| `vector` | `pip install crawler-to-md[vector]` | Parquet vector export via pyarrow (`--export-vectors`) |
+| `mcp` | `pip install crawler-to-md[mcp]` | MCP server (`crawler-to-md mcp`) |
+| `dev` | `pip install crawler-to-md[dev]` | pytest, ruff, pytest-cov |
+
+Extras can be combined:
+
+```shell
+pip install crawler-to-md[rag,vector]
+pip install crawler-to-md[readability,render,mcp]
 ```
 
 ## 🛠 Usage
 
-Start scraping with the following command:
+### Subcommands
+
+crawler-to-md now uses subcommands. The legacy `crawler-to-md --url ...` invocation is fully preserved — when no subcommand is given the tool defaults to `crawl`.
 
 ```shell
-crawler-to-md --url <URL> [--output-folder ./output] [--cache-folder ./cache] [--overwrite-cache|-w] [--base-url <BASE_URL>] [--exclude-url <KEYWORD_IN_URL>] [--title <TITLE>] [--urls-file <URLS_FILE>] [-p <PROXY_URL>]
+crawler-to-md crawl   --url <URL> [options]   # crawl a site and export
+crawler-to-md export  --url <URL> [options]   # re-export from an existing cache (no re-crawl)
+crawler-to-md mcp                             # start the MCP server over stdio
 ```
 
-Options:
+### Config file
+
+Place a `crawler-to-md.toml` file in your working directory and it is discovered automatically. Pass `--config path/to/file.toml` to use a different location. CLI flags always override config file values.
+
+```toml
+# crawler-to-md.toml — example
+url = "https://docs.example.com"
+output-folder = "./docs-export"
+concurrency = 4
+max-pages = 200
+export-llms = true
+chunk-size = 512
+chunk-overlap = 64
+```
+
+### `crawl` — full option reference
+
+```shell
+crawler-to-md crawl --url <URL> [--urls-file <FILE>] [options]
+```
+
+#### Input / output
 
 - `--url`, `-u`: The starting URL. 🌍
-- `--urls-file`: Path to a file containing URLs to scrape, one URL per line. If '-', read from stdin. 📁
-- `--output-folder`, `-o`: Where to save Markdown files (default: `./output`). 📂
-- `--cache-folder`, `-c`: Where to store the database (default: `./cache`). 💾
-- `--overwrite-cache`, `-w`: Overwrite existing cache database before scraping. 🧹
+- `--urls-file`: Path to a file containing URLs to scrape, one URL per line. If `-`, read from stdin. 📁
+- `--output-folder`, `-o`: Where to save output files (default: `./output`). 📂
+- `--cache-folder`, `-c`: Where to store the SQLite database (default: `~/.cache/crawler-to-md`). 💾
 - `--base-url`, `-b`: Filter links by base URL (default: URL's base). 🔎
-- `--title`, `-t`: Final title of the markdown file. Defaults to the URL. 🏷️
+- `--title`, `-t`: Title for the output files. Defaults to the URL. 🏷️
+- `--config`: Path to a `crawler-to-md.toml` config file. Auto-discovered in CWD when omitted. ⚙️
+
+#### Crawl control
+
+- `--overwrite-cache`, `-w`: Overwrite existing cache database before scraping. 🧹
 - `--exclude-url`, `-e`: Exclude URLs containing this string (repeatable). ❌
-- `--export-individual`, `-ei`: Export each page as an individual Markdown file. 📝
-- `--rate-limit`, `-rl`: Maximum number of requests per minute (default: 0, no rate limit). ⏱️
-- `--delay`, `-d`: Delay between requests in seconds (default: 0, no delay). 🕒
+- `--include-url`, `-I`: Include only URLs containing this string (repeatable). ✅
+- `--rate-limit`, `-rl`: Maximum number of requests per minute (default: 0, no limit). ⏱️
+- `--delay`, `-d`: Delay between requests in seconds (default: 0). 🕒
 - `--proxy`, `-p`: Proxy URL for HTTP or SOCKS requests. 🌐
+
+#### HTML filtering
+
 - `--include`, `-i`: CSS-like selector (#id, .class, tag) to include before Markdown conversion (repeatable). ✅
 - `--exclude`, `-x`: CSS-like selector (#id, .class, tag) to exclude before Markdown conversion (repeatable). 🚫
 
-One of the `--url` or `--urls-file` options is required.
+#### Robustness
+
+- `--timeout`: Per-request timeout in seconds (default: `15`). ⏳
+- `--max-retries`: Maximum retries on transient failures — timeouts, 429, 5xx — with exponential backoff (default: `3`). 🔁
+- `--max-pages`: Stop after scraping this many pages (`0` = unlimited). 📏
+- `--max-depth`: Maximum link-discovery depth (`-1` = unlimited). 🌊
+- `--max-time`: Maximum wall-clock crawl time in seconds (`0` = unlimited). ⏰
+
+#### Concurrency
+
+- `--concurrency N`: Number of parallel fetches. `1` (default) uses the synchronous engine; `N > 1` enables the async `httpx` engine with a bounded semaphore. Per-host politeness (rate limit, delay) is preserved in async mode. ⚡
+
+#### Intelligence
+
+- `--ignore-robots`: Disable robots.txt compliance (robots.txt is **honored by default**). 🤖
+- `--user-agent`: Custom User-Agent string sent on every request. 🪪
+- `--sitemap`: Seed the crawl frontier from the host's `/sitemap.xml` before crawling. 🗺️
+- `--extract {none,readability}`: Content-extraction strategy. `readability` uses trafilatura to strip boilerplate (requires `pip install crawler-to-md[readability]`). Default: `none`. 🧹
+- `--render`: Fetch JS-rendered HTML via Playwright (requires `pip install crawler-to-md[render]` and `playwright install chromium`). Off by default. 🎭
+- `--header "Key: Value"`: Extra request header (repeatable). 📬
+- `--cookie "key=value"`: Request cookie (repeatable). 🍪
+- `--auth user:pass`: HTTP Basic authentication credentials. 🔑
+- `--allow-types application/pdf`: Additional MIME types to ingest via MarkItDown — e.g. `application/pdf`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document` (repeatable). 📎
+
+#### Output formats
+
+- `--export-individual`, `-ei`: Export each page as an individual Markdown file. 📝
+- `--frontmatter` / `--no-frontmatter`: Prepend YAML frontmatter (url, title, fetched_at, word_count, token_count) to individual Markdown files. On by default. 🗂️
+- `--no-markdown`: Skip generation of the compiled Markdown file. 🚫
+- `--no-json`: Skip generation of the compiled JSON file. 🚫
+- `--export-jsonl`: Export pages as JSON Lines — one `{url, content, metadata}` record per line. 🗃️
+- `--export-llms`: Export `llms.txt` (page index) and `llms-full.txt` (full content) in the emerging LLM-friendly format. 🤖
+- `--chunk-size N`: Split pages into RAG chunks of `N` tokens (0 = disabled). Requires `pip install crawler-to-md[rag]`. 🧩
+- `--chunk-overlap N`: Token overlap between consecutive chunks (used when `--chunk-size > 0`). 🔗
+- `--export-vectors`: Export pages to a Parquet file for downstream vector indexing. Requires `pip install crawler-to-md[vector]`. 📊
+
+#### Run summary
+
+Every run prints an end-of-run summary to stdout:
+
+```
+Run summary
+  Links discovered : 142
+  Pages scraped    : 98
+  Pages stored     : 98
+  Content bytes    : 1048576
+  Total tokens     : 210340 (estimated)
+  Duration         : 34.21s
+```
+
+Token counts are exact when the `rag` extra is installed (tiktoken), or estimated otherwise.
+
+### `export` — re-export without re-crawling
+
+Re-run any combination of export formats from an existing cache database without hitting the network again. Accepts all the same output flags as `crawl`.
+
+```shell
+crawler-to-md export --url https://docs.example.com \
+  --export-llms --export-jsonl --chunk-size 512 --chunk-overlap 64
+```
+
+### `mcp` — MCP server
+
+Expose crawl tools to AI agents and orchestrators that speak the [Model Context Protocol](https://modelcontextprotocol.io/) over stdio.
+
+```shell
+# requires the mcp extra
+pip install crawler-to-md[mcp]
+crawler-to-md mcp
+```
+
+Tools exposed: `crawl` and `fetch_as_markdown`.
 
 ### 📚 Log level
 
-By default, the `WARN` level is used. You can change it with the `LOG_LEVEL` environment variable.
+By default, the `WARN` level is used. Change it with the `LOG_LEVEL` environment variable:
+
+```shell
+LOG_LEVEL=INFO crawler-to-md --url https://example.com
+```
+
+## 📦 Library API
+
+Use `crawler_to_md` as a library — no CLI side effects, no `sys.argv` parsing.
+
+```python
+from crawler_to_md import crawl
+
+result = crawl("https://docs.example.com", max_pages=50, concurrency=4)
+
+for page in result.pages:
+    print(page.url, len(page.content))
+
+print(f"Scraped {result.stats.pages_scraped} pages in {result.stats.duration:.1f}s")
+```
+
+`crawl()` returns a `CrawlResult` object with:
+
+- `result.pages` — list of scraped pages (url, content, metadata)
+- `result.stats` — aggregate run statistics (pages scraped, bytes, tokens, duration)
+- `result.exports` — paths of any files written (if export options are passed)
+
+## 🔧 Plugin System
+
+crawler-to-md exposes an entry-point-based plugin architecture for all four pipeline stages. See **[docs/plugins.md](docs/plugins.md)** for the full reference.
+
+### Entry-point groups
+
+| Stage | Group | Protocol method |
+|---|---|---|
+| **Formatter** | `crawler_to_md.formatters` | `export(manager, output_path, **options)` |
+| **Filter** | `crawler_to_md.filters` | `is_allowed(url) -> bool` |
+| **Processor** | `crawler_to_md.processors` | `process(html, url) -> str` |
+| **Fetcher** | `crawler_to_md.fetchers` | `fetch(url)` |
+
+All built-in output formats ship as first-party formatters (`markdown`, `json`, `jsonl`, `llms`, `individual`, `chunks`, `vectors`) and are wired live through the registry. Register your own by declaring an entry point in your package's `pyproject.toml`:
+
+```toml
+[project.entry-points."crawler_to_md.formatters"]
+my-format = "my_package.exporters:MyFormatter"
+```
+
+Once your package is installed, the plugin is discovered automatically. See `tests/sample_plugin.py` for a worked end-to-end example.
+
+> **Note**: The filter, processor, and fetcher plugin protocols and registries are defined and tested, but are not yet consumed by the crawl loop — see [Known Limitations](#-known-limitations--follow-ups).
 
 ## 🐳 Docker Support
 
@@ -99,6 +278,11 @@ docker run --rm \
   -v $(pwd)/output:/app/output \
   crawler-to-md --url <URL>
 ```
+
+## ⚠️ Known Limitations / Follow-ups
+
+- **Filter/processor/fetcher plugin protocols** are fully defined and tested but are not yet consumed by the crawl loop. Formatters are wired live; the other three stages are available for extension and will be integrated in a future release.
+- **Sitemap parsing** uses the stdlib `xml.etree.ElementTree`. For untrusted or adversarially crafted sitemaps, consider using `defusedxml` as a drop-in replacement to guard against XML DoS attacks (billion-laughs).
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,98 +1,122 @@
 # crawler-to-md 🌐✍️
 
-This Python-based web scraper fetches content from URLs and exports it into Markdown and JSON formats, specifically designed for simplicity, extensibility, and for uploading JSON files to GPT models. It is ideal for those looking to leverage web content for AI training or analysis. 🤖💡
+![Python](https://img.shields.io/badge/Python-3.10%2B-blue?logo=python&logoColor=white)
+![CI](https://github.com/obeone/crawler-to-md/actions/workflows/ci.yaml/badge.svg)
+![PyPI](https://img.shields.io/pypi/v/crawler-to-md?logo=pypi&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-Ready-blue?logo=docker&logoColor=white)
+![License](https://img.shields.io/badge/License-MIT-green)
 
-## 🚀 Quick Start
+Crawl websites and turn them into clean Markdown, JSON and LLM-ready datasets —
+built to feed GPTs, RAG pipelines and AI agents.
 
-(Or even better, **[use Docker!](#-docker-support) 🐳**)
+---
 
-### Recommended installation using pipx (isolated environment)
+## 🏗 Architecture
+
+```mermaid
+flowchart TB
+    subgraph Interfaces
+        CLI["CLI<br/>crawl · export · mcp"]
+        LIB["Library API<br/>crawl() → CrawlResult"]
+        MCP["MCP server<br/>crawl · fetch_as_markdown"]
+    end
+
+    CORE["core<br/>run_crawl · run_export"]
+    CLI --> CORE
+    LIB --> CORE
+    MCP --> CORE
+
+    subgraph Engine
+        SCRAPER["Scraper<br/>sync + async (httpx)"]
+        INTEL["Intelligence<br/>robots · sitemap<br/>readability · render"]
+        SCRAPER -.-> INTEL
+    end
+    CORE --> SCRAPER
+
+    DB[("DatabaseManager<br/>SQLite frontier + pages")]
+    SCRAPER --> DB
+
+    subgraph Output
+        EXPORT["ExportManager"]
+        REG{{"Plugin registry<br/>entry points"}}
+        FMT["Formatters<br/>md · json · jsonl · llms<br/>individual · chunks · vectors"]
+        EXPORT --> REG --> FMT
+    end
+    DB --> EXPORT
+```
+
+The pipeline: **interface → core orchestration → Scraper (sync or async) →
+SQLite store → ExportManager + pluggable formatters**. Crawl-intelligence
+features wrap the fetch/scrape stage; output formats are discovered through an
+entry-point plugin registry.
+
+---
+
+## ✨ Features
+
+| Area | Highlights |
+|---|---|
+| 🕷 **Crawling** | Link-following crawler with SQLite frontier, base-URL filtering, include/exclude URL patterns, rate limiting, delay, proxy (HTTP/SOCKS) |
+| 🔁 **Robustness** | Automatic retries with exponential backoff + jitter (429/5xx/`Retry-After`), per-request timeouts, crawl bounds (`--max-pages/--max-depth/--max-time`), content-hash refresh |
+| ⚡ **Concurrency** | Async `httpx` engine with bounded parallelism (`--concurrency N`); sync path preserved and verified for parity |
+| 🧠 **Intelligence** | `robots.txt` compliance, sitemap seeding, boilerplate extraction (trafilatura), JS rendering (Playwright), custom headers/cookies/auth, non-HTML ingestion (PDF/docx via MarkItDown) |
+| 🧩 **HTML shaping** | Include/exclude page elements with CSS-like selectors (`#id`, `.class`, `tag`) before conversion |
+| 🤖 **AI-ready output** | Markdown, JSON, JSONL, `llms.txt`/`llms-full.txt`, YAML frontmatter, token-aware RAG chunks, Parquet vectors, end-of-run token accounting |
+| 🔌 **Interfaces** | CLI subcommands, embeddable `crawl()` library API, and an MCP server for AI agents |
+| 🔧 **Extensible** | Entry-point plugin system for formatters, filters, processors and fetchers |
+| 🐳 **Packaging** | Lightweight core, optional extras, multi-arch Docker image |
+
+---
+
+## 📦 Installation
+
+### With Docker (recommended)
+
+```shell
+docker run --rm \
+  -v "$(pwd)/output:/app/output" \
+  -v crawler-cache:/home/app/.cache/crawler-to-md \
+  ghcr.io/obeone/crawler-to-md --url https://example.com
+```
+
+### With pipx (isolated) or pip
 
 ```shell
 pipx install crawler-to-md
-```
-
-### Alternatively, install with pip
-
-```shell
+# or
 pip install crawler-to-md
 ```
 
-Then run the scraper:
-
 ```shell
-crawler-to-md --url https://www.example.com
+crawler-to-md --url https://example.com
 ```
 
-## 🌟 Features
-
-- Scrapes web pages for content and metadata. 📄
-- Filters links by base URL. 🔍
-- Excludes URLs containing certain strings. ❌
-- Automatically finds links or can use a file of URLs to scrape. 🔗
-- Rate limiting and delay support. 🕘
-- Exports data to Markdown and JSON, ready for GPT uploads. 📤
-- Exports each page as an individual Markdown file if `--export-individual` is used. 📝
-- Uses SQLite for efficient data management. 📊
-- Configurable via command-line arguments or a `crawler-to-md.toml` config file. ⚙️
-- Include or exclude specific HTML elements using CSS-like selectors (#id, .class, tag) during Markdown conversion. 🧩
-- **Robustness**: automatic retries with exponential backoff, configurable timeouts, crawl bounds. 🔁
-- **Concurrency**: async `httpx` engine for parallel fetching (`--concurrency N`). ⚡
-- **Crawl intelligence**: robots.txt compliance, sitemap seeding, boilerplate extraction, JS rendering. 🧠
-- **AI-ready outputs**: JSONL, llms.txt/llms-full.txt, YAML frontmatter, RAG chunks, Parquet vectors. 🤖
-- **MCP server**: expose crawl tools to AI agents via the Model Context Protocol. 🔌
-- **Library API**: use `from crawler_to_md import crawl` in your own code. 📦
-- **Plugin system**: extend formatters, filters, processors, and fetchers via Python entry points. 🔧
-- Docker support. 🐳
-
-## 📋 Requirements
-
-Python 3.10 or higher is required.
-
-Project dependencies are managed with `pyproject.toml`. Install the core package with:
-
-```shell
-pip install crawler-to-md
-```
+Python 3.10+ required.
 
 ### Optional extras
 
-Heavy or niche features ship as optional extras so the core stays lightweight:
+Heavy or niche features ship as extras so the core stays lightweight:
 
 | Extra | Install | Enables |
 |---|---|---|
 | `readability` | `pip install crawler-to-md[readability]` | Boilerplate extraction via trafilatura (`--extract readability`) |
-| `render` | `pip install crawler-to-md[render]` | JS rendering via Playwright (`--render`). After install run `playwright install chromium`. |
-| `rag` | `pip install crawler-to-md[rag]` | Token-aware RAG chunking via tiktoken (`--chunk-size`/`--chunk-overlap`); exact token counts in the run summary |
-| `vector` | `pip install crawler-to-md[vector]` | Parquet vector export via pyarrow (`--export-vectors`) |
+| `render` | `pip install crawler-to-md[render]` | JS rendering via Playwright (`--render`); then `playwright install chromium` |
+| `rag` | `pip install crawler-to-md[rag]` | Token-aware RAG chunking (`--chunk-size/--chunk-overlap`) + exact token counts |
+| `vector` | `pip install crawler-to-md[vector]` | Parquet vector export (`--export-vectors`) |
 | `mcp` | `pip install crawler-to-md[mcp]` | MCP server (`crawler-to-md mcp`) |
 | `dev` | `pip install crawler-to-md[dev]` | pytest, ruff, pytest-cov |
 
-Extras can be combined:
+Extras combine: `pip install "crawler-to-md[rag,vector,mcp]"`.
 
-```shell
-pip install crawler-to-md[rag,vector]
-pip install crawler-to-md[readability,render,mcp]
-```
+---
 
-## 🛠 Usage
+## ⚙️ Configuration
 
-### Subcommands
-
-crawler-to-md now uses subcommands. The legacy `crawler-to-md --url ...` invocation is fully preserved — when no subcommand is given the tool defaults to `crawl`.
-
-```shell
-crawler-to-md crawl   --url <URL> [options]   # crawl a site and export
-crawler-to-md export  --url <URL> [options]   # re-export from an existing cache (no re-crawl)
-crawler-to-md mcp                             # start the MCP server over stdio
-```
-
-### Config file
-
-Place a `crawler-to-md.toml` file in your working directory and it is discovered automatically. Pass `--config path/to/file.toml` to use a different location. CLI flags always override config file values.
+Drop a `crawler-to-md.toml` in your working directory (auto-discovered, or pass
+`--config path.toml`). CLI flags always override file values.
 
 ```toml
-# crawler-to-md.toml — example
+# crawler-to-md.toml
 url = "https://docs.example.com"
 output-folder = "./docs-export"
 concurrency = 4
@@ -102,120 +126,128 @@ chunk-size = 512
 chunk-overlap = 64
 ```
 
-### `crawl` — full option reference
+Logging verbosity is controlled by the `LOG_LEVEL` environment variable
+(default `WARN`):
 
 ```shell
-crawler-to-md crawl --url <URL> [--urls-file <FILE>] [options]
+LOG_LEVEL=INFO crawler-to-md --url https://example.com
 ```
 
-#### Input / output
+---
 
-- `--url`, `-u`: The starting URL. 🌍
-- `--urls-file`: Path to a file containing URLs to scrape, one URL per line. If `-`, read from stdin. 📁
-- `--output-folder`, `-o`: Where to save output files (default: `./output`). 📂
-- `--cache-folder`, `-c`: Where to store the SQLite database (default: `~/.cache/crawler-to-md`). 💾
-- `--base-url`, `-b`: Filter links by base URL (default: URL's base). 🔎
-- `--title`, `-t`: Title for the output files. Defaults to the URL. 🏷️
-- `--config`: Path to a `crawler-to-md.toml` config file. Auto-discovered in CWD when omitted. ⚙️
+## 🛠 Usage
 
-#### Crawl control
+crawler-to-md uses subcommands. The legacy `crawler-to-md --url ...` invocation
+is fully preserved — with no subcommand it defaults to `crawl`.
 
-- `--overwrite-cache`, `-w`: Overwrite existing cache database before scraping. 🧹
-- `--exclude-url`, `-e`: Exclude URLs containing this string (repeatable). ❌
-- `--include-url`, `-I`: Include only URLs containing this string (repeatable). ✅
-- `--rate-limit`, `-rl`: Maximum number of requests per minute (default: 0, no limit). ⏱️
-- `--delay`, `-d`: Delay between requests in seconds (default: 0). 🕒
-- `--proxy`, `-p`: Proxy URL for HTTP or SOCKS requests. 🌐
+| Command | Purpose |
+|---|---|
+| `crawler-to-md crawl --url <URL> [options]` | Crawl a site and export (default) |
+| `crawler-to-md export --url <URL> [options]` | Re-export from an existing cache, no re-crawl |
+| `crawler-to-md mcp` | Start the MCP server over stdio |
 
-#### HTML filtering
+### `crawl` options
 
-- `--include`, `-i`: CSS-like selector (#id, .class, tag) to include before Markdown conversion (repeatable). ✅
-- `--exclude`, `-x`: CSS-like selector (#id, .class, tag) to exclude before Markdown conversion (repeatable). 🚫
+**Input / output**
 
-#### Robustness
+| Flag | Description |
+|---|---|
+| `--url`, `-u` | Starting URL |
+| `--urls-file` | File of URLs (one per line); `-` reads stdin |
+| `--output-folder`, `-o` | Output directory (default `./output`) |
+| `--cache-folder`, `-c` | SQLite cache dir (default `~/.cache/crawler-to-md`) |
+| `--base-url`, `-b` | Restrict links to this base (default: URL's base) |
+| `--title`, `-t` | Output title (default: the URL) |
+| `--config` | Path to a `crawler-to-md.toml` (auto-discovered in CWD) |
 
-- `--timeout`: Per-request timeout in seconds (default: `15`). ⏳
-- `--max-retries`: Maximum retries on transient failures — timeouts, 429, 5xx — with exponential backoff (default: `3`). 🔁
-- `--max-pages`: Stop after scraping this many pages (`0` = unlimited). 📏
-- `--max-depth`: Maximum link-discovery depth (`-1` = unlimited). 🌊
-- `--max-time`: Maximum wall-clock crawl time in seconds (`0` = unlimited). ⏰
+**Crawl control**
 
-#### Concurrency
+| Flag | Description |
+|---|---|
+| `--overwrite-cache`, `-w` | Drop the cache DB before scraping |
+| `--exclude-url`, `-e` | Skip URLs containing this string (repeatable) |
+| `--include-url`, `-I` | Keep only URLs containing this string (repeatable) |
+| `--rate-limit`, `-rl` | Max requests/minute (`0` = no limit) |
+| `--delay`, `-d` | Delay between requests, seconds |
+| `--proxy`, `-p` | HTTP or SOCKS proxy URL |
 
-- `--concurrency N`: Number of parallel fetches. `1` (default) uses the synchronous engine; `N > 1` enables the async `httpx` engine with a bounded semaphore. Per-host politeness (rate limit, delay) is preserved in async mode. ⚡
+**HTML filtering**
 
-#### Intelligence
+| Flag | Description |
+|---|---|
+| `--include`, `-i` | CSS-like selector to keep before conversion (repeatable) |
+| `--exclude`, `-x` | CSS-like selector to drop before conversion (repeatable) |
 
-- `--ignore-robots`: Disable robots.txt compliance (robots.txt is **honored by default**). 🤖
-- `--user-agent`: Custom User-Agent string sent on every request. 🪪
-- `--sitemap`: Seed the crawl frontier from the host's `/sitemap.xml` before crawling. 🗺️
-- `--extract {none,readability}`: Content-extraction strategy. `readability` uses trafilatura to strip boilerplate (requires `pip install crawler-to-md[readability]`). Default: `none`. 🧹
-- `--render`: Fetch JS-rendered HTML via Playwright (requires `pip install crawler-to-md[render]` and `playwright install chromium`). Off by default. 🎭
-- `--header "Key: Value"`: Extra request header (repeatable). 📬
-- `--cookie "key=value"`: Request cookie (repeatable). 🍪
-- `--auth user:pass`: HTTP Basic authentication credentials. 🔑
-- `--allow-types application/pdf`: Additional MIME types to ingest via MarkItDown — e.g. `application/pdf`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document` (repeatable). 📎
+**Robustness**
 
-#### Output formats
+| Flag | Description |
+|---|---|
+| `--timeout` | Per-request timeout, seconds (default `15`) |
+| `--max-retries` | Retries on transient failures (default `3`) |
+| `--max-pages` | Stop after N pages (`0` = unlimited) |
+| `--max-depth` | Max link-discovery depth (`-1` = unlimited) |
+| `--max-time` | Max wall-clock time, seconds (`0` = unlimited) |
 
-- `--export-individual`, `-ei`: Export each page as an individual Markdown file. 📝
-- `--frontmatter` / `--no-frontmatter`: Prepend YAML frontmatter (url, title, fetched_at, word_count, token_count) to individual Markdown files. On by default. 🗂️
-- `--no-markdown`: Skip generation of the compiled Markdown file. 🚫
-- `--no-json`: Skip generation of the compiled JSON file. 🚫
-- `--export-jsonl`: Export pages as JSON Lines — one `{url, content, metadata}` record per line. 🗃️
-- `--export-llms`: Export `llms.txt` (page index) and `llms-full.txt` (full content) in the emerging LLM-friendly format. 🤖
-- `--chunk-size N`: Split pages into RAG chunks of `N` tokens (0 = disabled). Requires `pip install crawler-to-md[rag]`. 🧩
-- `--chunk-overlap N`: Token overlap between consecutive chunks (used when `--chunk-size > 0`). 🔗
-- `--export-vectors`: Export pages to a Parquet file for downstream vector indexing. Requires `pip install crawler-to-md[vector]`. 📊
+**Concurrency**
 
-#### Run summary
+| Flag | Description |
+|---|---|
+| `--concurrency N` | `1` = sync engine (default); `N>1` = async `httpx` with a bounded semaphore (politeness preserved) |
 
-Every run prints an end-of-run summary to stdout:
+**Intelligence**
 
-```
-Run summary
-  Links discovered : 142
-  Pages scraped    : 98
-  Pages stored     : 98
-  Content bytes    : 1048576
-  Total tokens     : 210340 (estimated)
-  Duration         : 34.21s
-```
+| Flag | Description |
+|---|---|
+| `--ignore-robots` | Disable robots.txt (honored by default) |
+| `--user-agent` | Custom User-Agent on every request |
+| `--sitemap` | Seed the frontier from the host's `/sitemap.xml` |
+| `--extract {none,readability}` | Content extraction; `readability` needs `[readability]` |
+| `--render` | Fetch JS-rendered HTML; needs `[render]` + `playwright install chromium` |
+| `--header "K: V"` | Extra request header (repeatable) |
+| `--cookie "k=v"` | Request cookie (repeatable) |
+| `--auth user:pass` | HTTP Basic auth |
+| `--allow-types <mime>` | Extra MIME types to ingest via MarkItDown, e.g. `application/pdf` (repeatable) |
 
-Token counts are exact when the `rag` extra is installed (tiktoken), or estimated otherwise.
+**Output formats**
+
+| Flag | Description |
+|---|---|
+| `--export-individual`, `-ei` | One Markdown file per page |
+| `--frontmatter` / `--no-frontmatter` | YAML frontmatter on individual files (on by default) |
+| `--no-markdown` | Skip the compiled Markdown file |
+| `--no-json` | Skip the compiled JSON file |
+| `--export-jsonl` | JSON Lines, one `{url, content, metadata}` per line |
+| `--export-llms` | `llms.txt` (index) + `llms-full.txt` (full content) |
+| `--chunk-size N` | RAG chunks of N tokens (`0` = off); needs `[rag]` |
+| `--chunk-overlap N` | Token overlap between chunks |
+| `--export-vectors` | Parquet export for vector indexing; needs `[vector]` |
+
+Every run prints a summary (links discovered, pages scraped/stored, bytes,
+tokens, duration). Token counts are exact with the `rag` extra, estimated
+otherwise.
 
 ### `export` — re-export without re-crawling
-
-Re-run any combination of export formats from an existing cache database without hitting the network again. Accepts all the same output flags as `crawl`.
 
 ```shell
 crawler-to-md export --url https://docs.example.com \
   --export-llms --export-jsonl --chunk-size 512 --chunk-overlap 64
 ```
 
-### `mcp` — MCP server
-
-Expose crawl tools to AI agents and orchestrators that speak the [Model Context Protocol](https://modelcontextprotocol.io/) over stdio.
+### `mcp` — Model Context Protocol server
 
 ```shell
-# requires the mcp extra
-pip install crawler-to-md[mcp]
-crawler-to-md mcp
+pip install "crawler-to-md[mcp]"
+crawler-to-md mcp        # serves over stdio
 ```
 
-Tools exposed: `crawl` and `fetch_as_markdown`.
+Exposes the tools `crawl` and `fetch_as_markdown` to MCP-speaking agents and
+orchestrators. See **[docs/mcp.md](docs/mcp.md)**.
 
-### 📚 Log level
+---
 
-By default, the `WARN` level is used. Change it with the `LOG_LEVEL` environment variable:
+## 📚 Library API
 
-```shell
-LOG_LEVEL=INFO crawler-to-md --url https://example.com
-```
-
-## 📦 Library API
-
-Use `crawler_to_md` as a library — no CLI side effects, no `sys.argv` parsing.
+`crawler_to_md` is embeddable — no CLI side effects, no `sys.argv` parsing.
 
 ```python
 from crawler_to_md import crawl
@@ -223,67 +255,82 @@ from crawler_to_md import crawl
 result = crawl("https://docs.example.com", max_pages=50, concurrency=4)
 
 for page in result.pages:
-    print(page.url, len(page.content))
+    print(page["url"], len(page["content"]))
 
-print(f"Scraped {result.stats.pages_scraped} pages in {result.stats.duration:.1f}s")
+print(f"{result.stats.pages_scraped} pages in {result.stats.duration:.1f}s")
 ```
 
-`crawl()` returns a `CrawlResult` object with:
+`crawl()` returns a `CrawlResult` (`pages`, `stats`, `exports`). Full reference:
+**[docs/library.md](docs/library.md)**.
 
-- `result.pages` — list of scraped pages (url, content, metadata)
-- `result.stats` — aggregate run statistics (pages scraped, bytes, tokens, duration)
-- `result.exports` — paths of any files written (if export options are passed)
+---
 
-## 🔧 Plugin System
+## 🔧 Plugin system
 
-crawler-to-md exposes an entry-point-based plugin architecture for all four pipeline stages. See **[docs/plugins.md](docs/plugins.md)** for the full reference.
+An entry-point plugin architecture covers all four pipeline stages. Built-in
+output formats ship as first-party formatters wired live through the registry.
 
-### Entry-point groups
-
-| Stage | Group | Protocol method |
+| Stage | Entry-point group | Protocol method |
 |---|---|---|
-| **Formatter** | `crawler_to_md.formatters` | `export(manager, output_path, **options)` |
-| **Filter** | `crawler_to_md.filters` | `is_allowed(url) -> bool` |
-| **Processor** | `crawler_to_md.processors` | `process(html, url) -> str` |
-| **Fetcher** | `crawler_to_md.fetchers` | `fetch(url)` |
+| Formatter | `crawler_to_md.formatters` | `export(manager, output_path, **options)` |
+| Filter | `crawler_to_md.filters` | `is_allowed(url) -> bool` |
+| Processor | `crawler_to_md.processors` | `process(html, url) -> str` |
+| Fetcher | `crawler_to_md.fetchers` | `fetch(url)` |
 
-All built-in output formats ship as first-party formatters (`markdown`, `json`, `jsonl`, `llms`, `individual`, `chunks`, `vectors`) and are wired live through the registry. Register your own by declaring an entry point in your package's `pyproject.toml`:
+Register your own in your package's `pyproject.toml`:
 
 ```toml
 [project.entry-points."crawler_to_md.formatters"]
 my-format = "my_package.exporters:MyFormatter"
 ```
 
-Once your package is installed, the plugin is discovered automatically. See `tests/sample_plugin.py` for a worked end-to-end example.
+Full guide: **[docs/plugins.md](docs/plugins.md)**.
 
-> **Note**: The filter, processor, and fetcher plugin protocols and registries are defined and tested, but are not yet consumed by the crawl loop — see [Known Limitations](#-known-limitations--follow-ups).
+---
 
-## 🐳 Docker Support
-
-Run with Docker:
+## 🐳 Docker
 
 ```shell
+# Run the published image
 docker run --rm \
-  -v $(pwd)/output:/app/output \
-  -v cache:/home/app/.cache/crawler-to-md \
-  ghcr.io/obeone/crawler-to-md --url <URL>
-```
+  -v "$(pwd)/output:/app/output" \
+  -v crawler-cache:/home/app/.cache/crawler-to-md \
+  ghcr.io/obeone/crawler-to-md --url https://example.com
 
-Build from source:
-
-```shell
+# Build from source
 docker build -t crawler-to-md .
-
-docker run --rm \
-  -v $(pwd)/output:/app/output \
-  crawler-to-md --url <URL>
+docker run --rm -v "$(pwd)/output:/app/output" crawler-to-md --url https://example.com
 ```
 
-## ⚠️ Known Limitations / Follow-ups
+---
 
-- **Filter/processor/fetcher plugin protocols** are fully defined and tested but are not yet consumed by the crawl loop. Formatters are wired live; the other three stages are available for extension and will be integrated in a future release.
-- **Sitemap parsing** uses the stdlib `xml.etree.ElementTree`. For untrusted or adversarially crafted sitemaps, consider using `defusedxml` as a drop-in replacement to guard against XML DoS attacks (billion-laughs).
+## 🧪 Development
+
+```shell
+uv pip install -e ".[dev]"   # editable install with dev tools
+uv run --extra dev pytest    # run the test suite
+uv run --extra dev ruff check .   # lint
+```
+
+See **[docs/](docs/)** for deeper guides (configuration, library, MCP, plugins).
+
+---
+
+## ⚠️ Known limitations
+
+- The **filter/processor/fetcher** plugin protocols are defined and tested but
+  not yet consumed by the crawl loop (formatters are live); integration is
+  planned.
+- **Sitemap parsing** uses the stdlib `xml.etree.ElementTree`. For untrusted
+  sitemaps, consider `defusedxml` to guard against XML-expansion DoS.
+
+---
 
 ## 🤝 Contributing
 
-Contributions are welcome! Feel free to submit pull requests or open issues. 🌟
+Issues and pull requests are welcome. Run the test suite and `ruff` before
+submitting.
+
+## 📝 License
+
+[MIT](LICENSE) © Grégoire Compagnon ([obeone](https://github.com/obeone))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Web Scraper to Markdown 🌐✍️
+# crawler-to-md 🌐✍️
 
 This Python-based web scraper fetches content from URLs and exports it into Markdown and JSON formats, specifically designed for simplicity, extensibility, and for uploading JSON files to GPT models. It is ideal for those looking to leverage web content for AI training or analysis. 🤖💡
 

--- a/crawler_to_md/__init__.py
+++ b/crawler_to_md/__init__.py
@@ -1,1 +1,75 @@
-# Package initialization file
+"""crawler-to-md: crawl websites and export their content as Markdown/JSON.
+
+Besides the ``crawler-to-md`` command-line tool, the package exposes a small,
+side-effect-free library API. Import :func:`crawl` to run a crawl
+programmatically and receive a structured :class:`~crawler_to_md.core.CrawlResult`
+(pages plus statistics) with no argument parsing and no process exit. The core
+component classes are re-exported for advanced use.
+
+Example:
+    >>> from crawler_to_md import crawl
+    >>> result = crawl("https://example.com", max_pages=10)
+    >>> len(result.pages)
+    10
+"""
+
+import tempfile
+from typing import Optional
+
+from .core import CrawlConfig, CrawlResult, CrawlStats, run_crawl, run_export
+from .database_manager import DatabaseManager
+from .export_manager import ExportManager
+from .scraper import Scraper
+
+__all__ = [
+    "crawl",
+    "CrawlConfig",
+    "CrawlResult",
+    "CrawlStats",
+    "run_crawl",
+    "run_export",
+    "Scraper",
+    "ExportManager",
+    "DatabaseManager",
+]
+
+
+def crawl(url: Optional[str] = None, *, urls=None, **options) -> CrawlResult:
+    """Crawl a website programmatically and return structured results.
+
+    This is the clean library entry point: it parses no command-line
+    arguments, performs no CLI-only side effects (no printing, no
+    ``sys.exit``), and never writes export files unless the caller explicitly
+    asks for them. The crawled pages are always returned in
+    :attr:`CrawlResult.pages`.
+
+    Sensible library defaults differ from the CLI: compiled Markdown and JSON
+    exports are disabled, and an isolated temporary directory is used for the
+    SQLite cache unless ``cache_folder`` is supplied. Any field of
+    :class:`~crawler_to_md.core.CrawlConfig` may be passed as a keyword
+    override (for example ``max_pages``, ``max_depth``, ``concurrency``,
+    ``include_url``, ``output_folder`` together with ``no_markdown=False`` to
+    write artefacts).
+
+    Args:
+        url (str | None): The base URL to start crawling from.
+        urls (Iterable[str] | None): An explicit list of seed URLs. Either
+            ``url`` or ``urls`` must be provided.
+        **options: Keyword overrides mapped onto
+            :class:`~crawler_to_md.core.CrawlConfig`.
+
+    Returns:
+        CrawlResult: The crawled pages, aggregate statistics, and the paths of
+        any exports that were written.
+
+    Raises:
+        TypeError: If an unknown configuration option is supplied.
+        ValueError: If neither ``url`` nor ``urls`` is provided, or if scraper
+            construction fails (e.g. an unreachable proxy).
+    """
+    options.setdefault("no_markdown", True)
+    options.setdefault("no_json", True)
+    if not options.get("cache_folder"):
+        options["cache_folder"] = tempfile.mkdtemp(prefix="crawler-to-md-")
+    config = CrawlConfig(url=url, urls_list=list(urls or []), **options)
+    return run_crawl(config)

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import os
 import sys
+import time
 
 from . import log_setup, utils
 from .database_manager import DatabaseManager
@@ -240,6 +241,43 @@ def main():
         "application/pdf). Repeatable.",
         default=[],
     )
+    parser.add_argument(
+        "--export-jsonl",
+        action="store_true",
+        help="Export pages as JSON Lines (one {url, content, metadata} per line)",
+        default=False,
+    )
+    parser.add_argument(
+        "--export-llms",
+        action="store_true",
+        help="Export llms.txt (page index) and llms-full.txt (full content)",
+        default=False,
+    )
+    parser.add_argument(
+        "--frontmatter",
+        action=argparse.BooleanOptionalAction,
+        help="Prepend per-page YAML frontmatter to individual Markdown exports "
+        "(on by default; disable with --no-frontmatter)",
+        default=True,
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        help="RAG chunk size in tokens (0 = disabled). Requires the 'rag' extra.",
+        default=0,
+    )
+    parser.add_argument(
+        "--chunk-overlap",
+        type=int,
+        help="RAG chunk overlap in tokens (used when --chunk-size > 0)",
+        default=0,
+    )
+    parser.add_argument(
+        "--export-vectors",
+        action="store_true",
+        help="Export pages to a Parquet file. Requires the 'vector' extra.",
+        default=False,
+    )
 
     try:
         import argcomplete
@@ -347,6 +385,7 @@ def main():
     # Start the scraping process. Concurrency > 1 selects the async crawl
     # engine; 1 (the default) uses the synchronous path for identical behavior.
     logger.info(f"Starting the scraping process for URL: {args.url}")
+    start_time = time.perf_counter()
     if args.concurrency > 1:
         asyncio.run(
             scraper.start_scraping_async(url=args.url, urls_list=urls_list)
@@ -373,9 +412,43 @@ def main():
     if args.export_individual:
         logger.info("Export of individual pages...")
         output_folder_ei = export_manager.export_individual_markdown(
-            output_folder=output, base_url=args.base_url
+            output_folder=output,
+            base_url=args.base_url,
+            frontmatter=args.frontmatter,
         )
         logger.info("Export of individual Markdown files completed.")
+
+    jsonl_path = os.path.join(output, f"{output_name}.jsonl")
+    if args.export_jsonl:
+        export_manager.export_to_jsonl(jsonl_path)
+        logger.info("Export to JSONL completed.")
+
+    llms_paths = None
+    if args.export_llms:
+        llms_paths = export_manager.export_to_llms(output)
+        logger.info("Export to llms.txt completed.")
+
+    chunks_path = os.path.join(output, "chunks.jsonl")
+    chunk_count = None
+    if args.chunk_size > 0:
+        try:
+            chunk_count = export_manager.export_chunks_jsonl(
+                chunks_path, args.chunk_size, args.chunk_overlap
+            )
+            logger.info("Export of RAG chunks completed.")
+        except ImportError as exc:
+            print("\033[91m", exc, "\033[0m")
+
+    vectors_path = os.path.join(output, f"{output_name}.parquet")
+    vector_rows = None
+    if args.export_vectors:
+        try:
+            vector_rows = export_manager.export_to_vectors(
+                vectors_path, args.chunk_size, args.chunk_overlap
+            )
+            logger.info("Export to Parquet completed.")
+        except ImportError as exc:
+            print("\033[91m", exc, "\033[0m")
 
     markdown_path = os.path.join(output, f"{output_name}.md")
     json_path = os.path.join(output, f"{output_name}.json")
@@ -388,6 +461,49 @@ def main():
             "\033[95mIndividual Markdown files exported to: \033[0m",
             output_folder_ei,
         )
+    if args.export_jsonl:
+        print("\033[96mJSONL file generated at: \033[0m", jsonl_path)
+    if args.export_llms and llms_paths:
+        print("\033[96mllms.txt files generated at: \033[0m", llms_paths[0])
+    if chunk_count is not None:
+        print("\033[96mRAG chunks file generated at: \033[0m", chunks_path)
+    if vector_rows is not None:
+        print("\033[96mParquet vectors file generated at: \033[0m", vectors_path)
+
+    duration = time.perf_counter() - start_time
+    _print_run_summary(export_manager, db_manager, duration)
+
+
+def _print_run_summary(export_manager, db_manager, duration):
+    """
+    Print an end-of-run summary report to stdout.
+
+    The report covers the crawl frontier (total vs visited links), the corpus
+    size (pages and bytes of content), total token usage (exact via tiktoken
+    when the ``rag`` extra is installed, otherwise a labelled word-based
+    estimate) and the wall-clock duration.
+
+    Args:
+        export_manager (ExportManager): Used to compute corpus token totals.
+        db_manager (DatabaseManager): Source of link/page counts.
+        duration (float): Wall-clock crawl duration in seconds.
+    """
+    total_links = db_manager.get_links_count()
+    visited_links = db_manager.get_visited_links_count()
+    pages = db_manager.get_all_pages()
+    page_count = sum(1 for _u, content, _m in pages if content is not None)
+    total_bytes = sum(
+        len((content or "").encode("utf-8")) for _u, content, _m in pages
+    )
+    total_tokens, method, _measured = export_manager.compute_token_totals()
+
+    print("\033[1m\nRun summary\033[0m")
+    print(f"  Links discovered : {total_links}")
+    print(f"  Pages scraped    : {visited_links}")
+    print(f"  Pages stored     : {page_count}")
+    print(f"  Content bytes    : {total_bytes}")
+    print(f"  Total tokens     : {total_tokens} ({method})")
+    print(f"  Duration         : {duration:.2f}s")
 
 
 if __name__ == "__main__":

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -149,6 +149,36 @@ def main():
         ),
         default=[],
     )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        help="Per-request timeout in seconds",
+        default=15,
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        help="Maximum retries on transient failures (timeouts, 429, 5xx)",
+        default=3,
+    )
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        help="Maximum number of pages to scrape (0 = unlimited)",
+        default=0,
+    )
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        help="Maximum crawl depth for link discovery (-1 = unlimited)",
+        default=-1,
+    )
+    parser.add_argument(
+        "--max-time",
+        type=float,
+        help="Maximum wall-clock crawl time in seconds (0 = unlimited)",
+        default=0,
+    )
 
     try:
         import argcomplete
@@ -233,6 +263,11 @@ def main():
             proxy=args.proxy,
             include_filters=args.include,
             exclude_filters=args.exclude,
+            timeout=args.timeout,
+            max_retries=args.max_retries,
+            max_pages=args.max_pages,
+            max_depth=args.max_depth,
+            max_time=args.max_time,
         )
     except ValueError as exc:
         parser.error(str(exc))

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -186,6 +186,60 @@ def main():
         help="Number of concurrent fetches (1 = synchronous, the default)",
         default=1,
     )
+    parser.add_argument(
+        "--ignore-robots",
+        action="store_true",
+        help="Ignore robots.txt rules (robots is honored by default)",
+        default=False,
+    )
+    parser.add_argument(
+        "--user-agent",
+        help="User-Agent string sent on every request (default: descriptive UA)",
+        default=None,
+    )
+    parser.add_argument(
+        "--sitemap",
+        action="store_true",
+        help="Seed the frontier from the host's /sitemap.xml before crawling",
+        default=False,
+    )
+    parser.add_argument(
+        "--extract",
+        choices=["none", "readability"],
+        help="Content extraction strategy (readability requires the "
+        "'readability' extra)",
+        default="none",
+    )
+    parser.add_argument(
+        "--render",
+        action="store_true",
+        help="Fetch JS-rendered HTML via Playwright (requires the 'render' extra)",
+        default=False,
+    )
+    parser.add_argument(
+        "--header",
+        action="append",
+        help="Extra request header as 'Key: Value'. Repeatable.",
+        default=[],
+    )
+    parser.add_argument(
+        "--cookie",
+        action="append",
+        help="Request cookie as 'key=value'. Repeatable.",
+        default=[],
+    )
+    parser.add_argument(
+        "--auth",
+        help="HTTP basic-auth credentials as 'user:pass'",
+        default=None,
+    )
+    parser.add_argument(
+        "--allow-types",
+        action="append",
+        help="Additional content-type to ingest via MarkItDown (e.g. "
+        "application/pdf). Repeatable.",
+        default=[],
+    )
 
     try:
         import argcomplete
@@ -276,6 +330,15 @@ def main():
             max_depth=args.max_depth,
             max_time=args.max_time,
             concurrency=args.concurrency,
+            ignore_robots=args.ignore_robots,
+            user_agent=args.user_agent,
+            sitemap=args.sitemap,
+            extract=args.extract,
+            render=args.render,
+            headers=args.header,
+            cookies=args.cookie,
+            auth=args.auth,
+            allow_types=args.allow_types,
         )
     except ValueError as exc:
         parser.error(str(exc))

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -1,16 +1,25 @@
 import argparse
-import asyncio
 import logging
 import os
 import sys
-import time
+
+try:  # Python 3.11+ ships tomllib in the stdlib.
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised only on Python 3.10
+    import tomli as tomllib
 
 from . import log_setup, utils
-from .database_manager import DatabaseManager
-from .export_manager import ExportManager
-from .scraper import Scraper
+from .core import config_from_namespace, run_crawl, run_export
 
 logger = logging.getLogger(__name__)
+
+# Subcommands recognised at the top level. Anything else on the command line is
+# treated as arguments to the implicit ``crawl`` subcommand for backward
+# compatibility with the pre-subcommand ``crawler-to-md --url ...`` invocation.
+KNOWN_SUBCOMMANDS = ("crawl", "export", "mcp")
+
+# Default config file auto-discovered in the current working directory.
+DEFAULT_CONFIG_FILENAME = "crawler-to-md.toml"
 
 
 def configure_logging():
@@ -27,22 +36,13 @@ def configure_logging():
     log_setup.setup_logging(log_level)
 
 
-def main():
+def _add_io_arguments(parser):
     """
-    Main function to start the web scraper application.
+    Add the input/output arguments shared by the ``crawl`` and ``export`` subcommands.
 
-    This function parses command line arguments, initializes necessary components,
-    and manages the scraping and exporting process.
-
-    Raises:
-        ValueError: If neither a URL nor a URLs file is provided.
+    Args:
+        parser (argparse.ArgumentParser): The (sub)parser to populate.
     """
-    configure_logging()
-    logger.info("Starting the web scraper application.")
-
-
-    # Parse command line arguments
-    parser = argparse.ArgumentParser(description="Web Scraper to Markdown")
     parser.add_argument("--url", "-u", help="Base URL to start scraping")
     parser.add_argument(
         "--urls-file",
@@ -62,13 +62,6 @@ def main():
         default="~/.cache/crawler-to-md",
     )
     parser.add_argument(
-        "--overwrite-cache",
-        "-w",
-        action="store_true",
-        help="Overwrite existing cache database if present",
-        default=False,
-    )
-    parser.add_argument(
         "--base-url",
         "-b",
         help="Base URL for filtering links. Defaults to the URL base",
@@ -77,6 +70,93 @@ def main():
         "--title",
         "-t",
         help="Final title of the markdown file. Defaults to the URL",
+    )
+    parser.add_argument(
+        "--config",
+        help="Path to a crawler-to-md.toml config file (CLI flags override it). "
+        f"Auto-discovered as ./{DEFAULT_CONFIG_FILENAME} when omitted.",
+        default=None,
+    )
+
+
+def _add_export_arguments(parser):
+    """
+    Add the export-related arguments shared by ``crawl`` and ``export``.
+
+    Args:
+        parser (argparse.ArgumentParser): The (sub)parser to populate.
+    """
+    parser.add_argument(
+        "--export-individual",
+        "-ei",
+        action="store_true",
+        help="Export each page as an individual Markdown file",
+        default=False,
+    )
+    parser.add_argument(
+        "--no-markdown",
+        action="store_true",
+        help="Disable generation of the compiled Markdown file",
+        default=False,
+    )
+    parser.add_argument(
+        "--no-json",
+        action="store_true",
+        help="Disable generation of the compiled JSON file",
+        default=False,
+    )
+    parser.add_argument(
+        "--export-jsonl",
+        action="store_true",
+        help="Export pages as JSON Lines (one {url, content, metadata} per line)",
+        default=False,
+    )
+    parser.add_argument(
+        "--export-llms",
+        action="store_true",
+        help="Export llms.txt (page index) and llms-full.txt (full content)",
+        default=False,
+    )
+    parser.add_argument(
+        "--frontmatter",
+        action=argparse.BooleanOptionalAction,
+        help="Prepend per-page YAML frontmatter to individual Markdown exports "
+        "(on by default; disable with --no-frontmatter)",
+        default=True,
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        help="RAG chunk size in tokens (0 = disabled). Requires the 'rag' extra.",
+        default=0,
+    )
+    parser.add_argument(
+        "--chunk-overlap",
+        type=int,
+        help="RAG chunk overlap in tokens (used when --chunk-size > 0)",
+        default=0,
+    )
+    parser.add_argument(
+        "--export-vectors",
+        action="store_true",
+        help="Export pages to a Parquet file. Requires the 'vector' extra.",
+        default=False,
+    )
+
+
+def _add_crawl_only_arguments(parser):
+    """
+    Add the crawl-specific arguments (network, filtering, bounds).
+
+    Args:
+        parser (argparse.ArgumentParser): The ``crawl`` subparser to populate.
+    """
+    parser.add_argument(
+        "--overwrite-cache",
+        "-w",
+        action="store_true",
+        help="Overwrite existing cache database if present",
+        default=False,
     )
     parser.add_argument(
         "--exclude-url",
@@ -91,13 +171,6 @@ def main():
         action="append",
         help="Include only URLs containing this string",
         default=[],
-    )
-    parser.add_argument(
-        "--export-individual",
-        "-ei",
-        action="store_true",
-        help="Export each page as an individual Markdown file",
-        default=False,
     )
     parser.add_argument(
         "--rate-limit",
@@ -118,18 +191,6 @@ def main():
         "-p",
         help="Proxy URL for HTTP or SOCKS requests",
         default=None,
-    )
-    parser.add_argument(
-        "--no-markdown",
-        action="store_true",
-        help="Disable generation of the compiled Markdown file",
-        default=False,
-    )
-    parser.add_argument(
-        "--no-json",
-        action="store_true",
-        help="Disable generation of the compiled JSON file",
-        default=False,
     )
     parser.add_argument(
         "--include",
@@ -241,269 +302,297 @@ def main():
         "application/pdf). Repeatable.",
         default=[],
     )
-    parser.add_argument(
-        "--export-jsonl",
-        action="store_true",
-        help="Export pages as JSON Lines (one {url, content, metadata} per line)",
-        default=False,
-    )
-    parser.add_argument(
-        "--export-llms",
-        action="store_true",
-        help="Export llms.txt (page index) and llms-full.txt (full content)",
-        default=False,
-    )
-    parser.add_argument(
-        "--frontmatter",
-        action=argparse.BooleanOptionalAction,
-        help="Prepend per-page YAML frontmatter to individual Markdown exports "
-        "(on by default; disable with --no-frontmatter)",
-        default=True,
-    )
-    parser.add_argument(
-        "--chunk-size",
-        type=int,
-        help="RAG chunk size in tokens (0 = disabled). Requires the 'rag' extra.",
-        default=0,
-    )
-    parser.add_argument(
-        "--chunk-overlap",
-        type=int,
-        help="RAG chunk overlap in tokens (used when --chunk-size > 0)",
-        default=0,
-    )
-    parser.add_argument(
-        "--export-vectors",
-        action="store_true",
-        help="Export pages to a Parquet file. Requires the 'vector' extra.",
-        default=False,
-    )
 
+
+def build_parser():
+    """
+    Build the top-level argument parser and its subcommand parsers.
+
+    The parser exposes three subcommands — ``crawl`` (the default), ``export``
+    (re-run exports from an existing cache without crawling), and ``mcp`` (start
+    the MCP server). Every legacy ``crawl`` flag is preserved.
+
+    Returns:
+        tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentParser]]: The
+        top-level parser and a mapping of subcommand name to its subparser.
+    """
+    parser = argparse.ArgumentParser(description="Web Scraper to Markdown")
+    subparsers = parser.add_subparsers(dest="command")
+
+    crawl_parser = subparsers.add_parser(
+        "crawl", help="Crawl a site and export its content (default)"
+    )
+    _add_io_arguments(crawl_parser)
+    _add_crawl_only_arguments(crawl_parser)
+    _add_export_arguments(crawl_parser)
+
+    export_parser = subparsers.add_parser(
+        "export", help="Re-run exports from an existing cache database"
+    )
+    _add_io_arguments(export_parser)
+    _add_export_arguments(export_parser)
+
+    subparsers.add_parser("mcp", help="Start the MCP server over stdio")
+
+    return parser, {
+        "crawl": crawl_parser,
+        "export": export_parser,
+    }
+
+
+def _inject_default_subcommand(argv):
+    """
+    Inject the implicit ``crawl`` subcommand for legacy-style invocations.
+
+    Preserves backward compatibility: ``crawler-to-md --url ...`` (no
+    subcommand) behaves exactly as before by dispatching to ``crawl``. When the
+    first token is a known subcommand or a top-level help flag, the argument
+    list is returned unchanged.
+
+    Args:
+        argv (list[str]): The argument list excluding the program name.
+
+    Returns:
+        list[str]: The argument list with a subcommand guaranteed in front.
+    """
+    if not argv:
+        return ["crawl"]
+    first = argv[0]
+    if first in KNOWN_SUBCOMMANDS or first in ("-h", "--help"):
+        return list(argv)
+    return ["crawl"] + list(argv)
+
+
+def _extract_config_arg(argv):
+    """
+    Extract the value of ``--config`` from a raw argument list, if present.
+
+    Args:
+        argv (list[str]): The argument list to scan.
+
+    Returns:
+        str | None: The config path supplied via ``--config``/``--config=``, or
+        ``None`` if the flag is absent.
+    """
+    for index, token in enumerate(argv):
+        if token == "--config" and index + 1 < len(argv):
+            return argv[index + 1]
+        if token.startswith("--config="):
+            return token.split("=", 1)[1]
+    return None
+
+
+def _resolve_config_path(argv):
+    """
+    Resolve the config file path: explicit ``--config`` or CWD auto-discovery.
+
+    Args:
+        argv (list[str]): The argument list to scan for ``--config``.
+
+    Returns:
+        str | None: The path to use, or ``None`` when no config file applies.
+    """
+    explicit = _extract_config_arg(argv)
+    if explicit:
+        return explicit
+    default = os.path.join(os.getcwd(), DEFAULT_CONFIG_FILENAME)
+    if os.path.exists(default):
+        return default
+    return None
+
+
+def _load_config_file(path):
+    """
+    Load a ``crawler-to-md.toml`` config file into a flag-keyed dictionary.
+
+    Keys are normalised by replacing hyphens with underscores so that both
+    ``max-pages`` and ``max_pages`` map onto the ``max_pages`` flag. Read or
+    parse errors are logged and yield an empty mapping rather than aborting.
+
+    Args:
+        path (str): Path to the TOML config file.
+
+    Returns:
+        dict: Mapping of normalised flag name to its configured value.
+    """
     try:
-        import argcomplete
+        with open(path, "rb") as handle:
+            data = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        logger.warning("Could not read config file %s: %s", path, exc)
+        return {}
+    logger.debug("Loaded configuration from %s", path)
+    return {str(key).replace("-", "_"): value for key, value in data.items()}
 
 
-        argcomplete.autocomplete(parser)
-    except ImportError:
-        pass
+def _apply_config_file(argv, command, subparsers_map):
+    """
+    Apply config-file values as subparser defaults so CLI flags still override them.
+
+    Config values are installed via :meth:`argparse.ArgumentParser.set_defaults`
+    on the active subparser. Because argparse only falls back to a default when
+    the option is absent from the command line, any explicitly-passed CLI flag
+    wins over the file value.
+
+    Args:
+        argv (list[str]): The argument list (used to resolve ``--config``).
+        command (str): The active subcommand (``"crawl"`` or ``"export"``).
+        subparsers_map (dict[str, argparse.ArgumentParser]): Subparser registry.
+    """
+    if command not in subparsers_map:
+        return
+    config_path = _resolve_config_path(argv)
+    if not config_path:
+        return
+    file_values = _load_config_file(config_path)
+    if not file_values:
+        return
+    subparser = subparsers_map[command]
+    valid = {action.dest for action in subparser._actions}
+    valid -= {"help", "config", "command"}
+    overrides = {key: value for key, value in file_values.items() if key in valid}
+    if overrides:
+        subparser.set_defaults(**overrides)
 
 
-    args = parser.parse_args()
-    logger.debug(f"Command line arguments parsed: {args}")
+def _resolve_urls(args, parser):
+    """
+    Resolve the seed URL list from ``--urls-file``/stdin and validate input.
 
-    # Expand user path for cache folder
-    args.cache_folder = os.path.expanduser(args.cache_folder)
+    Args:
+        args (argparse.Namespace): The parsed arguments.
+        parser (argparse.ArgumentParser): Parser used to emit a usage error.
 
-    # Read URLs from a file or stdin
-    if args.urls_file:
-        if args.urls_file == "-":
+    Returns:
+        list[str]: The deduplicated seed URL list (empty in single-URL mode).
+    """
+    urls_file = getattr(args, "urls_file", None)
+    if urls_file:
+        if urls_file == "-":
             print("Enter URLs, one per line (Ctrl-D to finish):")
             urls_list = [line.strip() for line in sys.stdin]
         else:
-            with open(args.urls_file, "r") as file:
+            with open(urls_file, "r") as file:
                 urls_list = [line.strip() for line in file.readlines()]
-
-
         urls_list = utils.deduplicate_list(urls_list)
         args.url = None  # Ensure args.url is defined even if not used
     else:
         urls_list = []
 
-
-    if not args.url and not urls_list:
+    if not getattr(args, "url", None) and not urls_list:
         parser.error("No URL provided. Please provide either --url or --urls-file.")
-
-    first_url = args.url if args.url else urls_list[0]
-    output = os.path.join(args.output_folder, utils.url_to_filename(first_url))
-
-    # Create the output folder if it does not exist
-    if not os.path.exists(output):
-        logger.info(f"Creating output folder at {output}")
-        os.makedirs(output)
-
-    # Create the cache folder if it does not exist
-    if not os.path.exists(args.cache_folder):
-        logger.info(f"Creating cache folder at {args.cache_folder}")
-        os.makedirs(args.cache_folder)
-
-    # If no base url, set it to the url base
-    if not args.base_url:
-        if not args.urls_file:
-            args.base_url = utils.url_dirname(first_url)
-        logger.debug(f"No base URL provided. Setting base URL to {args.base_url}")
-
-    # If no title, set it to the url base
-    if not args.title:
-        args.title = first_url
-        logger.debug(f"No title provided. Setting title to {args.title}")
-
-    # Initialize managers
-    db_path = os.path.join(
-        args.cache_folder, utils.url_to_filename(first_url) + ".sqlite"
-    )
-    if args.overwrite_cache and os.path.exists(db_path):
-        logger.info(f"Removing existing cache database at {db_path}")
-        try:
-            os.remove(db_path)
-        except OSError as e:
-            logger.error(f"Failed to remove cache database at {db_path}: {e}")
-            sys.exit(1)
-    db_manager = DatabaseManager(db_path)
-    logger.info("DatabaseManager initialized.")
-
-    try:
-        scraper = Scraper(
-            base_url=args.base_url,
-            exclude_patterns=args.exclude_url,
-            include_url_patterns=args.include_url,
-            db_manager=db_manager,
-            rate_limit=args.rate_limit,
-            delay=args.delay,
-            proxy=args.proxy,
-            include_filters=args.include,
-            exclude_filters=args.exclude,
-            timeout=args.timeout,
-            max_retries=args.max_retries,
-            max_pages=args.max_pages,
-            max_depth=args.max_depth,
-            max_time=args.max_time,
-            concurrency=args.concurrency,
-            ignore_robots=args.ignore_robots,
-            user_agent=args.user_agent,
-            sitemap=args.sitemap,
-            extract=args.extract,
-            render=args.render,
-            headers=args.header,
-            cookies=args.cookie,
-            auth=args.auth,
-            allow_types=args.allow_types,
-        )
-    except ValueError as exc:
-        parser.error(str(exc))
-    logger.info("Scraper initialized.")
-
-    # Start the scraping process. Concurrency > 1 selects the async crawl
-    # engine; 1 (the default) uses the synchronous path for identical behavior.
-    logger.info(f"Starting the scraping process for URL: {args.url}")
-    start_time = time.perf_counter()
-    if args.concurrency > 1:
-        asyncio.run(
-            scraper.start_scraping_async(url=args.url, urls_list=urls_list)
-        )
-    else:
-        scraper.start_scraping(url=args.url, urls_list=urls_list)
-
-    output_name = utils.randomstring_to_filename(args.title)
-
-    # After the scraping process is completed in the main function
-    export_manager = ExportManager(db_manager, args.title)
-    logger.info("ExportManager initialized.")
+    return urls_list
 
 
-    if not args.no_markdown:
-        export_manager.export_to_markdown(os.path.join(output, f"{output_name}.md"))
-        logger.info("Export to markdown completed.")
+def _print_result(result):
+    """
+    Print the export file paths and the end-of-run summary to stdout.
 
-    if not args.no_json:
-        export_manager.export_to_json(os.path.join(output, f"{output_name}.json"))
-        logger.info("Export to JSON completed.")
-
-    output_folder_ei = None
-    if args.export_individual:
-        logger.info("Export of individual pages...")
-        output_folder_ei = export_manager.export_individual_markdown(
-            output_folder=output,
-            base_url=args.base_url,
-            frontmatter=args.frontmatter,
-        )
-        logger.info("Export of individual Markdown files completed.")
-
-    jsonl_path = os.path.join(output, f"{output_name}.jsonl")
-    if args.export_jsonl:
-        export_manager.export_to_jsonl(jsonl_path)
-        logger.info("Export to JSONL completed.")
-
-    llms_paths = None
-    if args.export_llms:
-        llms_paths = export_manager.export_to_llms(output)
-        logger.info("Export to llms.txt completed.")
-
-    chunks_path = os.path.join(output, "chunks.jsonl")
-    chunk_count = None
-    if args.chunk_size > 0:
-        try:
-            chunk_count = export_manager.export_chunks_jsonl(
-                chunks_path, args.chunk_size, args.chunk_overlap
-            )
-            logger.info("Export of RAG chunks completed.")
-        except ImportError as exc:
-            print("\033[91m", exc, "\033[0m")
-
-    vectors_path = os.path.join(output, f"{output_name}.parquet")
-    vector_rows = None
-    if args.export_vectors:
-        try:
-            vector_rows = export_manager.export_to_vectors(
-                vectors_path, args.chunk_size, args.chunk_overlap
-            )
-            logger.info("Export to Parquet completed.")
-        except ImportError as exc:
-            print("\033[91m", exc, "\033[0m")
-
-    markdown_path = os.path.join(output, f"{output_name}.md")
-    json_path = os.path.join(output, f"{output_name}.json")
-    if not args.no_markdown:
-        print("\033[94mMarkdown file generated at: \033[0m", markdown_path)
-    if not args.no_json:
-        print("\033[92mJSON file generated at: \033[0m", json_path)
-    if args.export_individual and output_folder_ei:
+    Args:
+        result (crawler_to_md.core.CrawlResult): The completed run result.
+    """
+    exports = result.exports
+    if "markdown" in exports:
+        print("\033[94mMarkdown file generated at: \033[0m", exports["markdown"])
+    if "json" in exports:
+        print("\033[92mJSON file generated at: \033[0m", exports["json"])
+    if "individual" in exports:
         print(
             "\033[95mIndividual Markdown files exported to: \033[0m",
-            output_folder_ei,
+            exports["individual"],
         )
-    if args.export_jsonl:
-        print("\033[96mJSONL file generated at: \033[0m", jsonl_path)
-    if args.export_llms and llms_paths:
-        print("\033[96mllms.txt files generated at: \033[0m", llms_paths[0])
-    if chunk_count is not None:
-        print("\033[96mRAG chunks file generated at: \033[0m", chunks_path)
-    if vector_rows is not None:
-        print("\033[96mParquet vectors file generated at: \033[0m", vectors_path)
+    if "jsonl" in exports:
+        print("\033[96mJSONL file generated at: \033[0m", exports["jsonl"])
+    if "llms" in exports:
+        print("\033[96mllms.txt files generated at: \033[0m", exports["llms"][0])
+    if "chunks" in exports:
+        print("\033[96mRAG chunks file generated at: \033[0m", exports["chunks"])
+    if "vectors" in exports:
+        print(
+            "\033[96mParquet vectors file generated at: \033[0m", exports["vectors"]
+        )
+    for message in exports.get("errors", {}).values():
+        print("\033[91m", message, "\033[0m")
 
-    duration = time.perf_counter() - start_time
-    _print_run_summary(export_manager, db_manager, duration)
+    _print_run_summary(result.stats)
 
 
-def _print_run_summary(export_manager, db_manager, duration):
+def _print_run_summary(stats):
     """
     Print an end-of-run summary report to stdout.
 
-    The report covers the crawl frontier (total vs visited links), the corpus
-    size (pages and bytes of content), total token usage (exact via tiktoken
-    when the ``rag`` extra is installed, otherwise a labelled word-based
-    estimate) and the wall-clock duration.
-
     Args:
-        export_manager (ExportManager): Used to compute corpus token totals.
-        db_manager (DatabaseManager): Source of link/page counts.
-        duration (float): Wall-clock crawl duration in seconds.
+        stats (crawler_to_md.core.CrawlStats): Aggregate run statistics.
     """
-    total_links = db_manager.get_links_count()
-    visited_links = db_manager.get_visited_links_count()
-    pages = db_manager.get_all_pages()
-    page_count = sum(1 for _u, content, _m in pages if content is not None)
-    total_bytes = sum(
-        len((content or "").encode("utf-8")) for _u, content, _m in pages
-    )
-    total_tokens, method, _measured = export_manager.compute_token_totals()
-
     print("\033[1m\nRun summary\033[0m")
-    print(f"  Links discovered : {total_links}")
-    print(f"  Pages scraped    : {visited_links}")
-    print(f"  Pages stored     : {page_count}")
-    print(f"  Content bytes    : {total_bytes}")
-    print(f"  Total tokens     : {total_tokens} ({method})")
-    print(f"  Duration         : {duration:.2f}s")
+    print(f"  Links discovered : {stats.links_discovered}")
+    print(f"  Pages scraped    : {stats.pages_scraped}")
+    print(f"  Pages stored     : {stats.pages_stored}")
+    print(f"  Content bytes    : {stats.content_bytes}")
+    print(f"  Total tokens     : {stats.total_tokens} ({stats.token_method})")
+    print(f"  Duration         : {stats.duration:.2f}s")
+
+
+def _run_mcp():
+    """
+    Start the MCP server, surfacing a clear error if the ``mcp`` extra is missing.
+    """
+    from . import mcp_server
+
+    try:
+        mcp_server.serve()
+    except RuntimeError as exc:
+        print("\033[91m", exc, "\033[0m")
+        sys.exit(1)
+
+
+def main():
+    """
+    Main entry point for the crawler-to-md command-line interface.
+
+    Dispatches to one of the ``crawl`` (default), ``export`` or ``mcp``
+    subcommands. Invocations without an explicit subcommand are routed to
+    ``crawl`` for backward compatibility. The heavy lifting is delegated to the
+    shared core orchestration in :mod:`crawler_to_md.core`.
+    """
+    configure_logging()
+    logger.info("Starting the web scraper application.")
+
+    argv = _inject_default_subcommand(sys.argv[1:])
+    parser, subparsers_map = build_parser()
+
+    command = argv[0] if argv else "crawl"
+    _apply_config_file(argv, command, subparsers_map)
+
+    try:
+        import argcomplete
+
+        argcomplete.autocomplete(parser)
+    except ImportError:
+        pass
+
+    args = parser.parse_args(argv)
+    logger.debug(f"Command line arguments parsed: {args}")
+
+    if args.command == "mcp":
+        _run_mcp()
+        return
+
+    urls_list = _resolve_urls(args, parser)
+    config = config_from_namespace(args, urls_list)
+
+    try:
+        if args.command == "export":
+            result = run_export(config)
+        else:
+            result = run_crawl(config)
+    except ValueError as exc:
+        parser.error(str(exc))
+    except OSError as exc:
+        logger.error("%s", exc)
+        sys.exit(1)
+
+    _print_result(result)
 
 
 if __name__ == "__main__":

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import logging
 import os
 import sys
@@ -179,6 +180,12 @@ def main():
         help="Maximum wall-clock crawl time in seconds (0 = unlimited)",
         default=0,
     )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        help="Number of concurrent fetches (1 = synchronous, the default)",
+        default=1,
+    )
 
     try:
         import argcomplete
@@ -268,14 +275,21 @@ def main():
             max_pages=args.max_pages,
             max_depth=args.max_depth,
             max_time=args.max_time,
+            concurrency=args.concurrency,
         )
     except ValueError as exc:
         parser.error(str(exc))
     logger.info("Scraper initialized.")
 
-    # Start the scraping process
+    # Start the scraping process. Concurrency > 1 selects the async crawl
+    # engine; 1 (the default) uses the synchronous path for identical behavior.
     logger.info(f"Starting the scraping process for URL: {args.url}")
-    scraper.start_scraping(url=args.url, urls_list=urls_list)
+    if args.concurrency > 1:
+        asyncio.run(
+            scraper.start_scraping_async(url=args.url, urls_list=urls_list)
+        )
+    else:
+        scraper.start_scraping(url=args.url, urls_list=urls_list)
 
     output_name = utils.randomstring_to_filename(args.title)
 

--- a/crawler_to_md/cli.py
+++ b/crawler_to_md/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import sys
 
@@ -7,14 +8,21 @@ from .database_manager import DatabaseManager
 from .export_manager import ExportManager
 from .scraper import Scraper
 
-# Setup logging based on environment variable or default to WARN level
-# before importing other modules.
-log_level = os.getenv("LOG_LEVEL", "WARN")
-log_setup.setup_logging(log_level)
+logger = logging.getLogger(__name__)
 
 
-logger = log_setup.get_logger()
-logger.name = "main"
+def configure_logging():
+    """
+    Configure application logging based on the environment.
+
+    Reads the desired level from the ``LOG_LEVEL`` environment variable
+    (defaulting to ``WARN``) and installs the Tqdm-aware coloredlogs handler
+    on the root logger. This is invoked explicitly from :func:`main` rather
+    than at import time so that importing the package never mutates global
+    logging state as a side effect.
+    """
+    log_level = os.getenv("LOG_LEVEL", "WARN")
+    log_setup.setup_logging(log_level)
 
 
 def main():
@@ -27,6 +35,7 @@ def main():
     Raises:
         ValueError: If neither a URL nor a URLs file is provided.
     """
+    configure_logging()
     logger.info("Starting the web scraper application.")
 
 

--- a/crawler_to_md/core.py
+++ b/crawler_to_md/core.py
@@ -1,0 +1,539 @@
+"""Shared crawl/export orchestration used by both the CLI and the library API.
+
+This module centralises the wiring that turns a :class:`CrawlConfig` into a
+crawl (and optional exports), returning a structured :class:`CrawlResult`. It
+contains **no** argument parsing and performs **no** CLI-only side effects
+(no printing, no ``sys.exit``); the CLI in :mod:`crawler_to_md.cli` is a thin
+wrapper that builds a config, calls :func:`run_crawl`, and renders the result,
+while the public :func:`crawler_to_md.crawl` helper reuses the same core.
+"""
+
+import dataclasses
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from . import utils
+from .database_manager import DatabaseManager
+from .export_manager import ExportManager
+from .scraper import Scraper
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CrawlConfig:
+    """Declarative configuration for a crawl or re-export run.
+
+    The field names mirror the CLI flag destinations exactly so a parsed
+    :class:`argparse.Namespace` can be mapped onto this dataclass field by
+    field. Defaults match the CLI defaults, which keeps the library and CLI
+    behaviour aligned.
+
+    Attributes:
+        url (str | None): Single base URL to start crawling from.
+        urls_list (list[str]): Explicit list of seed URLs (mutually exclusive
+            with ``url`` in practice; either may be supplied).
+        output_folder (str): Root folder for exported artefacts.
+        cache_folder (str): Folder holding the per-site SQLite cache database.
+        overwrite_cache (bool): Remove an existing cache database before
+            crawling.
+        base_url (str | None): Base URL used for link filtering; derived from
+            the seed URL when omitted (single-URL mode only).
+        title (str | None): Title for the compiled outputs; defaults to the
+            seed URL.
+        exclude_url (list[str]): URL substrings to exclude.
+        include_url (list[str]): URL substrings that must be present.
+        export_individual (bool): Export each page as an individual Markdown
+            file.
+        rate_limit (int): Maximum requests per minute (``0`` = unlimited).
+        delay (float): Delay between requests in seconds.
+        proxy (str | None): Proxy URL for HTTP/SOCKS requests.
+        no_markdown (bool): Disable the compiled Markdown export.
+        no_json (bool): Disable the compiled JSON export.
+        include (list[str]): CSS-like selectors to include before conversion.
+        exclude (list[str]): CSS-like selectors to exclude before conversion.
+        timeout (float): Per-request timeout in seconds.
+        max_retries (int): Maximum retries on transient failures.
+        max_pages (int): Maximum pages to scrape (``0`` = unlimited).
+        max_depth (int): Maximum crawl depth (``-1`` = unlimited).
+        max_time (float): Maximum wall-clock crawl time (``0`` = unlimited).
+        concurrency (int): Concurrent fetches (``1`` = synchronous path).
+        ignore_robots (bool): Ignore ``robots.txt`` rules.
+        user_agent (str | None): User-Agent string for every request.
+        sitemap (bool): Seed the frontier from ``/sitemap.xml``.
+        extract (str): Content extraction strategy (``"none"`` or
+            ``"readability"``).
+        render (bool): Fetch JS-rendered HTML via Playwright.
+        header (list[str]): Extra request headers as ``"Key: Value"`` strings.
+        cookie (list[str]): Cookies as ``"key=value"`` strings.
+        auth (str | None): HTTP basic-auth credentials as ``"user:pass"``.
+        allow_types (list[str]): Additional content-types to ingest.
+        export_jsonl (bool): Export pages as JSON Lines.
+        export_llms (bool): Export ``llms.txt`` / ``llms-full.txt``.
+        frontmatter (bool): Prepend YAML frontmatter to individual Markdown.
+        chunk_size (int): RAG chunk size in tokens (``0`` = disabled).
+        chunk_overlap (int): RAG chunk overlap in tokens.
+        export_vectors (bool): Export pages to a Parquet file.
+    """
+
+    url: Optional[str] = None
+    urls_list: list = field(default_factory=list)
+    output_folder: str = "./output"
+    cache_folder: str = "~/.cache/crawler-to-md"
+    overwrite_cache: bool = False
+    base_url: Optional[str] = None
+    title: Optional[str] = None
+    exclude_url: list = field(default_factory=list)
+    include_url: list = field(default_factory=list)
+    export_individual: bool = False
+    rate_limit: int = 0
+    delay: float = 0
+    proxy: Optional[str] = None
+    no_markdown: bool = False
+    no_json: bool = False
+    include: list = field(default_factory=list)
+    exclude: list = field(default_factory=list)
+    timeout: float = 15
+    max_retries: int = 3
+    max_pages: int = 0
+    max_depth: int = -1
+    max_time: float = 0
+    concurrency: int = 1
+    ignore_robots: bool = False
+    user_agent: Optional[str] = None
+    sitemap: bool = False
+    extract: str = "none"
+    render: bool = False
+    header: list = field(default_factory=list)
+    cookie: list = field(default_factory=list)
+    auth: Optional[str] = None
+    allow_types: list = field(default_factory=list)
+    export_jsonl: bool = False
+    export_llms: bool = False
+    frontmatter: bool = True
+    chunk_size: int = 0
+    chunk_overlap: int = 0
+    export_vectors: bool = False
+
+
+@dataclass
+class CrawlStats:
+    """Aggregate statistics describing a completed crawl/export run.
+
+    Attributes:
+        links_discovered (int): Total links recorded in the frontier.
+        pages_scraped (int): Number of links marked visited.
+        pages_stored (int): Number of stored pages with non-empty content.
+        content_bytes (int): Total UTF-8 byte size of stored content.
+        total_tokens (int): Total token count across the corpus.
+        token_method (str): How tokens were counted (``"tiktoken"`` or
+            ``"word-estimate"``).
+        duration (float): Wall-clock duration of the run in seconds.
+    """
+
+    links_discovered: int = 0
+    pages_scraped: int = 0
+    pages_stored: int = 0
+    content_bytes: int = 0
+    total_tokens: int = 0
+    token_method: str = "word-estimate"
+    duration: float = 0.0
+
+
+@dataclass
+class CrawlResult:
+    """Structured result returned by :func:`run_crawl` and :func:`run_export`.
+
+    Attributes:
+        pages (list[dict]): One ``{"url", "content", "metadata"}`` entry per
+            stored page (``metadata`` decoded to a ``dict``).
+        stats (CrawlStats): Aggregate run statistics.
+        exports (dict[str, Any]): Mapping of export name to the path(s) written
+            (only the exports that were actually requested appear here).
+    """
+
+    pages: list = field(default_factory=list)
+    stats: CrawlStats = field(default_factory=CrawlStats)
+    exports: dict = field(default_factory=dict)
+
+
+def _first_url(config: CrawlConfig) -> Optional[str]:
+    """Return the primary seed URL for path/title derivation.
+
+    Args:
+        config (CrawlConfig): The run configuration.
+
+    Returns:
+        str | None: ``config.url`` when set, otherwise the first entry of
+        ``config.urls_list``, or ``None`` if neither is provided.
+    """
+    if config.url:
+        return config.url
+    if config.urls_list:
+        return config.urls_list[0]
+    return None
+
+
+def _apply_defaults(config: CrawlConfig, first_url: str) -> None:
+    """Fill in the derived ``base_url`` and ``title`` defaults in place.
+
+    Mirrors the legacy CLI behaviour: ``base_url`` is derived from the seed
+    URL only in single-URL mode (when no explicit URL list is supplied), and
+    ``title`` defaults to the seed URL.
+
+    Args:
+        config (CrawlConfig): The run configuration to mutate.
+        first_url (str): The resolved primary seed URL.
+    """
+    if not config.base_url and not config.urls_list:
+        config.base_url = utils.url_dirname(first_url)
+        logger.debug("No base URL provided. Setting base URL to %s", config.base_url)
+    if not config.title:
+        config.title = first_url
+        logger.debug("No title provided. Setting title to %s", config.title)
+
+
+def _db_path(config: CrawlConfig, first_url: str) -> str:
+    """Compute the SQLite cache path for ``first_url``.
+
+    Args:
+        config (CrawlConfig): The run configuration (provides ``cache_folder``).
+        first_url (str): The resolved primary seed URL.
+
+    Returns:
+        str: Absolute-ish path to the per-site SQLite database file.
+    """
+    cache_folder = os.path.expanduser(config.cache_folder)
+    return os.path.join(cache_folder, utils.url_to_filename(first_url) + ".sqlite")
+
+
+def _build_scraper(config: CrawlConfig, db_manager: DatabaseManager) -> Scraper:
+    """Construct a :class:`Scraper` from the configuration.
+
+    Args:
+        config (CrawlConfig): The run configuration.
+        db_manager (DatabaseManager): The database manager to wire in.
+
+    Returns:
+        Scraper: A configured scraper instance.
+
+    Raises:
+        ValueError: Propagated from :class:`Scraper` when a proxy is provided
+            but unreachable.
+    """
+    return Scraper(
+        base_url=config.base_url,
+        exclude_patterns=config.exclude_url,
+        include_url_patterns=config.include_url,
+        db_manager=db_manager,
+        rate_limit=config.rate_limit,
+        delay=config.delay,
+        proxy=config.proxy,
+        include_filters=config.include,
+        exclude_filters=config.exclude,
+        timeout=config.timeout,
+        max_retries=config.max_retries,
+        max_pages=config.max_pages,
+        max_depth=config.max_depth,
+        max_time=config.max_time,
+        concurrency=config.concurrency,
+        ignore_robots=config.ignore_robots,
+        user_agent=config.user_agent,
+        sitemap=config.sitemap,
+        extract=config.extract,
+        render=config.render,
+        headers=config.header,
+        cookies=config.cookie,
+        auth=config.auth,
+        allow_types=config.allow_types,
+    )
+
+
+def _wants_exports(config: CrawlConfig) -> bool:
+    """Return whether any export artefact is requested by ``config``.
+
+    Args:
+        config (CrawlConfig): The run configuration.
+
+    Returns:
+        bool: ``True`` if at least one export will be written.
+    """
+    return any(
+        (
+            not config.no_markdown,
+            not config.no_json,
+            config.export_individual,
+            config.export_jsonl,
+            config.export_llms,
+            config.chunk_size > 0,
+            config.export_vectors,
+        )
+    )
+
+
+def _run_exports(
+    export_manager: ExportManager, config: CrawlConfig, output: str
+) -> dict:
+    """Run every requested export, returning a name → path(s) mapping.
+
+    The output folder is created on demand. Optional-extra exports (RAG chunks
+    and Parquet vectors) surface their :class:`ImportError` to the caller via a
+    captured ``errors`` channel rather than aborting the whole run.
+
+    Args:
+        export_manager (ExportManager): The export manager bound to the cache.
+        config (CrawlConfig): The run configuration.
+        output (str): The per-site output folder.
+
+    Returns:
+        dict: Mapping of export name to the written path(s). A special
+        ``"errors"`` key maps export names to error messages when an
+        optional-extra export could not run.
+    """
+    exports: dict[str, Any] = {}
+    errors: dict[str, str] = {}
+    os.makedirs(output, exist_ok=True)
+    output_name = utils.randomstring_to_filename(config.title)
+
+    if not config.no_markdown:
+        path = os.path.join(output, f"{output_name}.md")
+        export_manager.export_to_markdown(path)
+        exports["markdown"] = path
+
+    if not config.no_json:
+        path = os.path.join(output, f"{output_name}.json")
+        export_manager.export_to_json(path)
+        exports["json"] = path
+
+    if config.export_individual:
+        exports["individual"] = export_manager.export_individual_markdown(
+            output_folder=output,
+            base_url=config.base_url,
+            frontmatter=config.frontmatter,
+        )
+
+    if config.export_jsonl:
+        path = os.path.join(output, f"{output_name}.jsonl")
+        export_manager.export_to_jsonl(path)
+        exports["jsonl"] = path
+
+    if config.export_llms:
+        exports["llms"] = export_manager.export_to_llms(output)
+
+    if config.chunk_size > 0:
+        path = os.path.join(output, "chunks.jsonl")
+        try:
+            export_manager.export_chunks_jsonl(
+                path, config.chunk_size, config.chunk_overlap
+            )
+            exports["chunks"] = path
+        except ImportError as exc:
+            errors["chunks"] = str(exc)
+
+    if config.export_vectors:
+        path = os.path.join(output, f"{output_name}.parquet")
+        try:
+            export_manager.export_to_vectors(
+                path, config.chunk_size, config.chunk_overlap
+            )
+            exports["vectors"] = path
+        except ImportError as exc:
+            errors["vectors"] = str(exc)
+
+    if errors:
+        exports["errors"] = errors
+    return exports
+
+
+def _read_pages(db_manager: DatabaseManager) -> list:
+    """Read all stored pages as structured dictionaries.
+
+    Args:
+        db_manager (DatabaseManager): The database manager to read from.
+
+    Returns:
+        list[dict]: One ``{"url", "content", "metadata"}`` entry per page,
+        with ``metadata`` decoded from its JSON string to a ``dict``.
+    """
+    pages = []
+    for url, content, metadata in db_manager.get_all_pages():
+        try:
+            decoded = json.loads(metadata) if metadata else {}
+        except (TypeError, ValueError):
+            decoded = {}
+        pages.append({"url": url, "content": content, "metadata": decoded})
+    return pages
+
+
+def _compute_stats(
+    db_manager: DatabaseManager, export_manager: ExportManager, duration: float
+) -> CrawlStats:
+    """Compute aggregate statistics for the run.
+
+    Args:
+        db_manager (DatabaseManager): Source of link/page counts.
+        export_manager (ExportManager): Used to compute corpus token totals.
+        duration (float): Wall-clock crawl duration in seconds.
+
+    Returns:
+        CrawlStats: The populated statistics record.
+    """
+    pages = db_manager.get_all_pages()
+    page_count = sum(1 for _u, content, _m in pages if content is not None)
+    total_bytes = sum(
+        len((content or "").encode("utf-8")) for _u, content, _m in pages
+    )
+    total_tokens, method, _measured = export_manager.compute_token_totals()
+    return CrawlStats(
+        links_discovered=db_manager.get_links_count(),
+        pages_scraped=db_manager.get_visited_links_count(),
+        pages_stored=page_count,
+        content_bytes=total_bytes,
+        total_tokens=total_tokens,
+        token_method=method,
+        duration=duration,
+    )
+
+
+def run_crawl(config: CrawlConfig) -> CrawlResult:
+    """Crawl according to ``config`` and run any requested exports.
+
+    This is the single orchestration entry point shared by the CLI and the
+    library API. It performs no printing and never calls ``sys.exit``; errors
+    propagate as exceptions for the caller to handle.
+
+    Args:
+        config (CrawlConfig): The fully-resolved run configuration. Either
+            ``config.url`` or ``config.urls_list`` must be set.
+
+    Returns:
+        CrawlResult: The crawled pages, aggregate statistics, and the paths of
+        any exports that were written.
+
+    Raises:
+        ValueError: If no seed URL is provided, or if scraper construction
+            fails (e.g. an unreachable proxy).
+        OSError: If an existing cache database cannot be removed when
+            ``overwrite_cache`` is set.
+    """
+    first_url = _first_url(config)
+    if not first_url:
+        raise ValueError("No URL provided. Provide either a URL or a URL list.")
+
+    _apply_defaults(config, first_url)
+
+    cache_folder = os.path.expanduser(config.cache_folder)
+    os.makedirs(cache_folder, exist_ok=True)
+
+    db_path = _db_path(config, first_url)
+    if config.overwrite_cache and os.path.exists(db_path):
+        logger.info("Removing existing cache database at %s", db_path)
+        try:
+            os.remove(db_path)
+        except OSError as exc:
+            logger.error("Failed to remove cache database at %s: %s", db_path, exc)
+            raise
+
+    db_manager = DatabaseManager(db_path)
+    logger.info("DatabaseManager initialized.")
+
+    scraper = _build_scraper(config, db_manager)
+    logger.info("Scraper initialized.")
+
+    start_time = time.perf_counter()
+    logger.info("Starting the scraping process for URL: %s", config.url)
+    if config.concurrency > 1:
+        import asyncio
+
+        asyncio.run(
+            scraper.start_scraping_async(
+                url=config.url, urls_list=config.urls_list
+            )
+        )
+    else:
+        scraper.start_scraping(url=config.url, urls_list=config.urls_list)
+
+    export_manager = ExportManager(db_manager, config.title)
+    exports: dict[str, Any] = {}
+    if _wants_exports(config):
+        output = os.path.join(
+            config.output_folder, utils.url_to_filename(first_url)
+        )
+        exports = _run_exports(export_manager, config, output)
+
+    duration = time.perf_counter() - start_time
+    stats = _compute_stats(db_manager, export_manager, duration)
+    pages = _read_pages(db_manager)
+    db_manager.close()
+
+    return CrawlResult(pages=pages, stats=stats, exports=exports)
+
+
+def run_export(config: CrawlConfig) -> CrawlResult:
+    """Re-run exports from an existing cache database without crawling.
+
+    Args:
+        config (CrawlConfig): The run configuration. Either ``config.url`` or
+            ``config.urls_list`` must locate the existing cache database.
+
+    Returns:
+        CrawlResult: The stored pages, statistics, and written export paths.
+
+    Raises:
+        ValueError: If no seed URL is provided, or if no cache database exists
+            at the derived path.
+    """
+    first_url = _first_url(config)
+    if not first_url:
+        raise ValueError("No URL provided. Provide either a URL or a URL list.")
+
+    _apply_defaults(config, first_url)
+
+    db_path = _db_path(config, first_url)
+    if not os.path.exists(db_path):
+        raise ValueError(
+            f"No cache database found at {db_path}. Run a crawl first or "
+            "point --cache-folder at the directory holding it."
+        )
+
+    db_manager = DatabaseManager(db_path)
+    export_manager = ExportManager(db_manager, config.title)
+
+    output = os.path.join(config.output_folder, utils.url_to_filename(first_url))
+    exports = _run_exports(export_manager, config, output)
+
+    stats = _compute_stats(db_manager, export_manager, 0.0)
+    pages = _read_pages(db_manager)
+    db_manager.close()
+
+    return CrawlResult(pages=pages, stats=stats, exports=exports)
+
+
+def config_from_namespace(args, urls_list: Optional[list] = None) -> CrawlConfig:
+    """Build a :class:`CrawlConfig` from a parsed ``argparse`` namespace.
+
+    Only attributes present on ``args`` overwrite the dataclass defaults, so a
+    subparser that exposes a subset of flags (e.g. ``export``) still yields a
+    valid configuration.
+
+    Args:
+        args (argparse.Namespace): The parsed command-line arguments.
+        urls_list (list[str] | None): Pre-resolved seed URL list (from a URLs
+            file or stdin). Defaults to an empty list.
+
+    Returns:
+        CrawlConfig: The populated configuration.
+    """
+    config = CrawlConfig()
+    for f in dataclasses.fields(CrawlConfig):
+        if f.name in ("url", "urls_list"):
+            continue
+        if hasattr(args, f.name):
+            setattr(config, f.name, getattr(args, f.name))
+    config.url = getattr(args, "url", None)
+    config.urls_list = list(urls_list or [])
+    return config

--- a/crawler_to_md/database_manager.py
+++ b/crawler_to_md/database_manager.py
@@ -251,6 +251,26 @@ class DatabaseManager:
             cursor = self.conn.execute("SELECT url, content, metadata FROM pages")
             return cursor.fetchall()
 
+    def get_all_pages_full(self):
+        """
+        Retrieve all pages with their refresh metadata.
+
+        Unlike :meth:`get_all_pages`, this returns the extra columns added in
+        Wave 1 so callers that need provenance (e.g. YAML frontmatter) can
+        access ``fetched_at`` without a per-URL lookup. It is additive: the
+        legacy three-column accessor is preserved for existing callers.
+
+        Returns:
+            list[tuple]: List of ``(url, content, metadata, content_hash,
+            fetched_at)`` tuples for every stored page.
+        """
+        with self.conn:
+            logger.debug("Retrieving all pages with refresh metadata")
+            cursor = self.conn.execute(
+                "SELECT url, content, metadata, content_hash, fetched_at FROM pages"
+            )
+            return cursor.fetchall()
+
     def get_page(self, url):
         """
         Retrieve a single page row by URL.

--- a/crawler_to_md/database_manager.py
+++ b/crawler_to_md/database_manager.py
@@ -1,7 +1,33 @@
+import hashlib
 import logging
 import sqlite3
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
+
+
+def _utcnow_iso():
+    """
+    Return the current UTC time as an ISO 8601 string.
+
+    Returns:
+        str: The current UTC timestamp (e.g. ``"2026-05-29T12:34:56.789+00:00"``).
+    """
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _content_hash(content):
+    """
+    Compute a stable SHA-256 hash of page content.
+
+    Args:
+        content (str | None): The page content. ``None`` is treated as an
+            empty string so that missing content hashes deterministically.
+
+    Returns:
+        str: The hexadecimal SHA-256 digest of the content.
+    """
+    return hashlib.sha256((content or "").encode("utf-8")).hexdigest()
 
 
 class DatabaseManager:
@@ -26,6 +52,11 @@ class DatabaseManager:
     def create_tables(self):
         """
         Create tables 'pages' and 'links' if they do not exist in the database.
+
+        For databases created before Wave 1, the additive columns introduced
+        for content refresh (``content_hash``, ``fetched_at``) and crawl bounds
+        (``depth``) are added via a guarded migration so existing user caches
+        keep working without data loss.
         """
         with self.conn:
             logger.debug("Creating tables 'pages' and 'links' if they do not exist")
@@ -33,40 +64,105 @@ class DatabaseManager:
                 """CREATE TABLE IF NOT EXISTS pages (
                           url TEXT PRIMARY KEY,
                           content TEXT,
-                          metadata TEXT)"""
+                          metadata TEXT,
+                          content_hash TEXT,
+                          fetched_at TEXT)"""
             )
             self.conn.execute(
                 """CREATE TABLE IF NOT EXISTS links (
                           url TEXT PRIMARY KEY,
-                          visited BOOLEAN)"""
+                          visited BOOLEAN,
+                          depth INTEGER DEFAULT 0)"""
             )
+            self._ensure_columns(
+                "pages",
+                {"content_hash": "content_hash TEXT", "fetched_at": "fetched_at TEXT"},
+            )
+            self._ensure_columns("links", {"depth": "depth INTEGER DEFAULT 0"})
+
+    def _ensure_columns(self, table, columns):
+        """
+        Ensure that ``table`` contains every column in ``columns``.
+
+        Missing columns are added with ``ALTER TABLE ... ADD COLUMN``. This is
+        the safe, additive migration path for SQLite, which cannot add multiple
+        columns in a single statement and offers no ``IF NOT EXISTS`` clause.
+
+        Args:
+            table (str): Name of the table to migrate. Must be a trusted,
+                hard-coded identifier (never user input).
+            columns (dict[str, str]): Mapping of column name to the column
+                definition fragment used in the ``ADD COLUMN`` statement.
+        """
+        existing = {row[1] for row in self.conn.execute(f"PRAGMA table_info({table})")}
+        for name, definition in columns.items():
+            if name not in existing:
+                logger.debug("Adding column %s to table %s", name, table)
+                self.conn.execute(f"ALTER TABLE {table} ADD COLUMN {definition}")
 
     def insert_page(self, url, content, metadata):
         """
-        Insert a new page into the 'pages' table.
+        Insert or refresh a page in the 'pages' table.
+
+        Performs an upsert keyed on ``url``: a new page is inserted, while an
+        existing page only has its ``content``/``metadata`` rewritten when the
+        SHA-256 hash of ``content`` differs from the stored hash. The
+        ``fetched_at`` timestamp is always refreshed so callers can tell when a
+        page was last seen, even if its content was unchanged.
 
         Args:
-        url (str): The URL of the page.
-        content (str): The content of the page.
-        metadata (str): The metadata of the page.
-        """
-        with self.conn:
-            logger.debug(f"Inserting a new page with URL: {url}")
-            self.conn.execute(
-                "INSERT OR IGNORE INTO pages (url, content, metadata) VALUES (?, ?, ?)",
-                (url, content, metadata),
-            )
+            url (str): The URL of the page.
+            content (str | None): The content of the page.
+            metadata (str): The metadata of the page (JSON-encoded string).
 
-    def insert_link(self, url, visited=False):
+        Returns:
+            bool: ``True`` if the content was inserted or changed, ``False`` if
+            the page already existed with identical content (only
+            ``fetched_at`` refreshed).
+        """
+        content_hash = _content_hash(content)
+        fetched_at = _utcnow_iso()
+        with self.conn:
+            cur = self.conn.execute(
+                "SELECT content_hash FROM pages WHERE url = ?", (url,)
+            )
+            row = cur.fetchone()
+            changed = row is None or row[0] != content_hash
+            logger.debug(
+                "Upserting page %s (changed=%s)", url, changed
+            )
+            self.conn.execute(
+                """
+                INSERT INTO pages (url, content, metadata, content_hash, fetched_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(url) DO UPDATE SET
+                    content = CASE
+                        WHEN pages.content_hash IS NOT excluded.content_hash
+                        THEN excluded.content ELSE pages.content END,
+                    metadata = CASE
+                        WHEN pages.content_hash IS NOT excluded.content_hash
+                        THEN excluded.metadata ELSE pages.metadata END,
+                    content_hash = excluded.content_hash,
+                    fetched_at = excluded.fetched_at
+                """,
+                (url, content, metadata, content_hash, fetched_at),
+            )
+            return changed
+
+    def insert_link(self, url, visited=False, depth=0):
         """
         Insert a new link into the 'links' table if it does not exist.
 
         Args:
-        url (str | List[str]): The URL or list of URLs of the link(s).
-        visited (bool): The status of the link (default is False).
+            url (str | List[str]): The URL or list of URLs of the link(s).
+            visited (bool): The status of the link (default is False).
+            depth (int): Crawl depth of the link(s) relative to the seed URLs
+                (seeds are depth 0, links discovered on them depth 1, ...).
+                Defaults to ``0``.
 
         Returns:
-        bool: True if the link is inserted, False if it already exists.
+            bool: True if at least one link is inserted, False if all already
+            exist.
         """
         if isinstance(url, str):
             urls = [url]
@@ -80,8 +176,9 @@ class DatabaseManager:
             for link in urls:
                 logger.debug(f"Inserting a new link with URL: {link}")
                 cur = self.conn.execute(
-                    "INSERT OR IGNORE INTO links (url, visited) VALUES (?, ?)",
-                    (link, visited),
+                    "INSERT OR IGNORE INTO links (url, visited, depth) "
+                    "VALUES (?, ?, ?)",
+                    (link, visited, depth),
                 )
                 if cur.rowcount > 0:
                     count += 1
@@ -101,14 +198,19 @@ class DatabaseManager:
 
     def get_unvisited_links(self):
         """
-        Retrieve all unvisited links from the 'links' table.
+        Retrieve all unvisited links from the 'links' table, shallowest first.
 
         Returns:
-        list: List of unvisited links.
+            list[tuple[str, int]]: List of ``(url, depth)`` tuples for every
+            unvisited link, ordered by ascending depth so the crawl proceeds
+            breadth-first.
         """
         with self.conn:
             logger.debug("Retrieving all unvisited links")
-            cursor = self.conn.execute("SELECT url FROM links WHERE visited = FALSE")
+            cursor = self.conn.execute(
+                "SELECT url, depth FROM links WHERE visited = FALSE "
+                "ORDER BY depth ASC"
+            )
             return cursor.fetchall()
 
     def get_links_count(self):
@@ -148,6 +250,25 @@ class DatabaseManager:
             logger.debug("Retrieving all pages")
             cursor = self.conn.execute("SELECT url, content, metadata FROM pages")
             return cursor.fetchall()
+
+    def get_page(self, url):
+        """
+        Retrieve a single page row by URL.
+
+        Args:
+            url (str): The URL of the page to fetch.
+
+        Returns:
+            tuple | None: ``(url, content, metadata, content_hash, fetched_at)``
+            if the page exists, otherwise ``None``.
+        """
+        with self.conn:
+            cursor = self.conn.execute(
+                "SELECT url, content, metadata, content_hash, fetched_at "
+                "FROM pages WHERE url = ?",
+                (url,),
+            )
+            return cursor.fetchone()
 
     def close(self):
         """

--- a/crawler_to_md/database_manager.py
+++ b/crawler_to_md/database_manager.py
@@ -14,6 +14,13 @@ class DatabaseManager:
         """
         logger.debug(f"Connecting to the database at {db_path}")
         self.conn = sqlite3.connect(db_path)
+        # Enable Write-Ahead Logging for better concurrency and crash safety.
+        # WAL is not supported for in-memory databases, so skip it there.
+        if db_path != ":memory:":
+            try:
+                self.conn.execute("PRAGMA journal_mode=WAL")
+            except sqlite3.Error as exc:
+                logger.warning("Could not enable WAL journal mode: %s", exc)
         self.create_tables()
 
     def create_tables(self):
@@ -142,9 +149,51 @@ class DatabaseManager:
             cursor = self.conn.execute("SELECT url, content, metadata FROM pages")
             return cursor.fetchall()
 
+    def close(self):
+        """
+        Close the underlying SQLite connection if it is still open.
+
+        This method is idempotent: calling it more than once, or after the
+        connection has already been closed, is safe and has no effect.
+        """
+        conn = getattr(self, "conn", None)
+        if conn is not None:
+            logger.debug("Closing the database connection")
+            conn.close()
+            self.conn = None
+
+    def __enter__(self):
+        """
+        Enter the runtime context and return the manager itself.
+
+        Returns:
+            DatabaseManager: This instance, ready for use within a ``with`` block.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """
+        Exit the runtime context, ensuring the database connection is closed.
+
+        Args:
+            exc_type (type | None): Exception type raised in the context, if any.
+            exc_value (BaseException | None): Exception instance raised, if any.
+            traceback (types.TracebackType | None): Traceback associated with the
+                exception, if any.
+
+        Returns:
+            bool: ``False`` so that any exception raised within the context is
+            propagated rather than suppressed.
+        """
+        self.close()
+        return False
+
     def __del__(self):
         """
-        Close the database connection when the object is deleted.
+        Close the database connection when the object is garbage collected.
+
+        Acts as a safety net only; the connection is guarded with
+        :func:`getattr` so that a partially initialized instance (where
+        ``conn`` was never assigned) does not raise during deletion.
         """
-        logger.debug("Closing the database connection")
-        self.conn.close()
+        self.close()

--- a/crawler_to_md/export_manager.py
+++ b/crawler_to_md/export_manager.py
@@ -1,11 +1,10 @@
 import json
+import logging
 import os
 
-from . import log_setup
 from .database_manager import DatabaseManager
 
-logger = log_setup.get_logger()
-logger.name = "export_manager"
+logger = logging.getLogger(__name__)
 
 
 class ExportManager:
@@ -93,9 +92,9 @@ class ExportManager:
                 "\n" + metadata_content + "\n\n" + adjusted_content + "\n---"
             )  # Add a separator and metadata
 
-            final_content = self._cleanup_markdown(final_content)
-
-        return final_content
+        # Run cleanup once after the loop instead of on every iteration to avoid
+        # O(n^2) reprocessing of the accumulated content.
+        return self._cleanup_markdown(final_content)
 
     def export_to_markdown(self, output_path):
         """

--- a/crawler_to_md/export_manager.py
+++ b/crawler_to_md/export_manager.py
@@ -4,6 +4,7 @@ import os
 
 from . import rag
 from .database_manager import DatabaseManager
+from .plugins import get_registry
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,34 @@ class ExportManager:
         self.db_manager = db_manager
         self.title = title
         logger.info("ExportManager initialized.")  # Add log message
+
+    def export_with(self, formatter_name, output_path, **options):
+        """
+        Run a registered formatter by name through the plugin registry.
+
+        This re-expresses every export as a discoverable
+        :class:`~crawler_to_md.plugins.Formatter`. First-party formatters
+        delegate to the corresponding ``export_to_*`` method, so the output is
+        byte-identical to calling that method directly; third-party formatters
+        registered via the ``crawler_to_md.formatters`` entry-point group are
+        equally usable here.
+
+        Args:
+            formatter_name (str): Registered formatter name (e.g. ``"markdown"``,
+                ``"json"``, ``"jsonl"``, ``"llms"``, ``"individual"``,
+                ``"chunks"``, ``"vectors"``).
+            output_path (str): Destination path or folder for the formatter.
+            **options: Formatter-specific options (e.g. ``base_url``,
+                ``frontmatter``, ``chunk_size``, ``chunk_overlap``).
+
+        Returns:
+            Any: Whatever the underlying formatter returns.
+
+        Raises:
+            KeyError: If no formatter is registered under ``formatter_name``.
+        """
+        formatter = get_registry().create("formatters", formatter_name)
+        return formatter.export(self, output_path, **options)
 
     def _adjust_headers(self, content, level_increment=1):
         """

--- a/crawler_to_md/export_manager.py
+++ b/crawler_to_md/export_manager.py
@@ -2,9 +2,37 @@ import json
 import logging
 import os
 
+from . import rag
 from .database_manager import DatabaseManager
 
 logger = logging.getLogger(__name__)
+
+# Actionable error shown when the Parquet/vector export is requested without
+# the optional ``vector`` extra installed.
+VECTOR_MISSING_MESSAGE = (
+    "Vector/Parquet export requires the optional 'vector' extra. "
+    "Install it with: pip install crawler-to-md[vector]"
+)
+
+
+def _yaml_escape(value):
+    """
+    Render ``value`` as a safe single-line YAML scalar.
+
+    Strings are double-quoted with backslashes and quotes escaped so that
+    titles or URLs containing special characters cannot break the frontmatter
+    block. Non-string values are emitted via ``str`` (used for integers).
+
+    Args:
+        value: The value to serialise.
+
+    Returns:
+        str: A YAML-safe scalar representation of ``value``.
+    """
+    if isinstance(value, str):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return str(value)
 
 
 class ExportManager:
@@ -135,29 +163,77 @@ class ExportManager:
             # Log the successful export to JSON file
             logger.info(f"Exported pages to JSON file: {output_path}")
 
-    def export_individual_markdown(self, output_folder, base_url=None):
+    def _build_frontmatter(self, url, content, metadata_dict, fetched_at):
+        """
+        Build a YAML frontmatter block for a single page.
+
+        The block always carries ``url``, ``title``, ``fetched_at`` and
+        ``word_count``. ``token_count`` is included only when the optional
+        ``rag`` extra (tiktoken) is installed, so a bare installation simply
+        omits that key rather than failing.
+
+        Args:
+            url (str): The page URL.
+            content (str): The page Markdown content.
+            metadata_dict (dict): Parsed page metadata (may contain ``title``).
+            fetched_at (str or None): ISO timestamp of the last fetch, if known.
+
+        Returns:
+            str: A YAML frontmatter block terminated by a trailing newline.
+        """
+        title = metadata_dict.get("title") or url
+        word_count = len((content or "").split())
+
+        lines = ["---"]
+        lines.append(f"url: {_yaml_escape(url)}")
+        lines.append(f"title: {_yaml_escape(title)}")
+        if fetched_at:
+            lines.append(f"fetched_at: {_yaml_escape(fetched_at)}")
+        lines.append(f"word_count: {word_count}")
+
+        try:
+            token_count = rag.count_tokens(content)
+        except ImportError:
+            token_count = None
+        if token_count is not None:
+            lines.append(f"token_count: {token_count}")
+
+        lines.append("---")
+        return "\n".join(lines) + "\n\n"
+
+    def export_individual_markdown(self, output_folder, base_url=None,
+                                   frontmatter=True):
         """
         Export each page individually as Markdown, preserving the URL's structure.
 
         Args:
             output_folder (str): The base output folder where the files will be saved.
             base_url (str or None): Base URL to remove for creating the path.
+            frontmatter (bool): When ``True`` (the default), prepend a per-page
+                YAML frontmatter block (url, title, fetched_at, word_count and,
+                if the ``rag`` extra is installed, token_count). When ``False``,
+                the previous behaviour (raw content only) is preserved.
+
+        Returns:
+            str: The folder the individual files were written to.
         """
-        pages = self.db_manager.get_all_pages()
+        pages = self.db_manager.get_all_pages_full()
         # Add 'files/' to the output folder and create it if it doesn't exist
         output_folder = os.path.join(output_folder, "files")
 
         os.makedirs(output_folder, exist_ok=True)
-        for page in pages:
-            url, content, metadata = page
+        for url, content, metadata, _content_hash, fetched_at in pages:
             logger.debug(f"Exporting individual Markdown for URL: {url}")
 
+            metadata_dict = json.loads(metadata) if metadata else {}
+
             # Remove base_url from parsed URL if provided
+            display_url = url
             if base_url:
-                url = url.replace(base_url, "")
+                display_url = display_url.replace(base_url, "")
 
             # Parse the URL to determine the folder and filename
-            parsed_url = url.replace("https://", "").replace("http://", "")
+            parsed_url = display_url.replace("https://", "").replace("http://", "")
             if parsed_url.endswith("/") or parsed_url == "":
                 file_path = os.path.join(output_folder, parsed_url, "index.md")
             else:
@@ -166,9 +242,260 @@ class ExportManager:
             # Ensure directories exist
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
+            body = content or ""
+            if frontmatter:
+                body = self._build_frontmatter(
+                    url, content, metadata_dict, fetched_at
+                ) + body
+
             # Write the Markdown content
             with open(file_path, "w", encoding="utf-8") as file:
-                file.write(content)
+                file.write(body)
                 logger.debug(f"Markdown exported to {file_path}")
 
         return output_folder
+
+    def export_to_jsonl(self, output_path):
+        """
+        Export the pages as JSON Lines (one record per line).
+
+        Each non-empty page is emitted as a single-line JSON object with
+        ``url``, ``content`` (cleaned) and ``metadata`` (null values stripped),
+        matching the structure of :meth:`export_to_json` but in a
+        streaming-friendly, AI-ingestion-ready format.
+
+        Args:
+            output_path (str): Destination path for the ``.jsonl`` file.
+        """
+        pages = self.db_manager.get_all_pages()
+        with open(output_path, "w", encoding="utf-8") as jsonl_file:
+            for url, content, metadata in pages:
+                if content is None:
+                    continue  # Skip empty pages
+
+                cleaned = self._cleanup_markdown(content)
+                filtered_metadata = {
+                    k: v for k, v in json.loads(metadata).items() if v is not None
+                }
+                record = {
+                    "url": url,
+                    "content": cleaned,
+                    "metadata": filtered_metadata,
+                }
+                jsonl_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+        logger.info(f"Exported pages to JSONL file: {output_path}")
+
+    def export_to_llms(self, output_folder):
+        """
+        Export ``llms.txt`` and ``llms-full.txt`` for LLM consumption.
+
+        Follows the emerging `llms.txt convention <https://llmstxt.org/>`_:
+
+        * ``llms.txt`` — an H1 title, an optional blockquote summary and a
+          ``## Pages`` section listing every page as a Markdown link.
+        * ``llms-full.txt`` — the H1 title followed by the full content of every
+          page, separated by horizontal rules.
+
+        Args:
+            output_folder (str): Folder the two files are written to.
+
+        Returns:
+            tuple[str, str]: The ``(llms.txt, llms-full.txt)`` paths written.
+        """
+        pages = self.db_manager.get_all_pages()
+        title = self.title or "Site"
+
+        index_path = os.path.join(output_folder, "llms.txt")
+        full_path = os.path.join(output_folder, "llms-full.txt")
+
+        index_lines = [f"# {title}", ""]
+        index_lines.append(f"> Index of {len(pages)} crawled pages.")
+        index_lines.append("")
+        index_lines.append("## Pages")
+        index_lines.append("")
+
+        full_lines = [f"# {title}", ""]
+
+        for url, content, metadata in pages:
+            if content is None:
+                continue  # Skip empty pages
+
+            metadata_dict = json.loads(metadata) if metadata else {}
+            page_title = metadata_dict.get("title") or url
+            index_lines.append(f"- [{page_title}]({url})")
+
+            full_lines.append(f"## {page_title}")
+            full_lines.append(f"<{url}>")
+            full_lines.append("")
+            full_lines.append(self._cleanup_markdown(content))
+            full_lines.append("")
+            full_lines.append("---")
+            full_lines.append("")
+
+        with open(index_path, "w", encoding="utf-8") as index_file:
+            index_file.write("\n".join(index_lines) + "\n")
+        with open(full_path, "w", encoding="utf-8") as full_file:
+            full_file.write("\n".join(full_lines) + "\n")
+
+        logger.info(f"Exported llms.txt index to {index_path}")
+        logger.info(f"Exported llms-full.txt content to {full_path}")
+        return index_path, full_path
+
+    def export_chunks_jsonl(self, output_path, chunk_size, chunk_overlap=0):
+        """
+        Export token-aware RAG chunks as JSON Lines.
+
+        Each page's content is split into overlapping, token-bounded chunks via
+        :func:`crawler_to_md.rag.chunk_text` and emitted one record per line as
+        ``{url, chunk_index, content, token_count}``.
+
+        Args:
+            output_path (str): Destination path for the ``chunks.jsonl`` file.
+            chunk_size (int): Maximum tokens per chunk (must be ``> 0``).
+            chunk_overlap (int): Tokens shared between consecutive chunks.
+
+        Returns:
+            int: The total number of chunk records written.
+
+        Raises:
+            ValueError: If ``chunk_size`` is not a positive integer.
+            ImportError: If the ``rag`` extra (tiktoken) is not installed.
+        """
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be a positive integer to chunk")
+
+        encoder = rag.get_encoder()
+        pages = self.db_manager.get_all_pages()
+        total = 0
+        with open(output_path, "w", encoding="utf-8") as chunk_file:
+            for url, content, _metadata in pages:
+                if content is None:
+                    continue  # Skip empty pages
+
+                cleaned = self._cleanup_markdown(content)
+                chunks = rag.chunk_text(
+                    cleaned, chunk_size, chunk_overlap, encoder=encoder
+                )
+                for index, (chunk_content, token_count) in enumerate(chunks):
+                    record = {
+                        "url": url,
+                        "chunk_index": index,
+                        "content": chunk_content,
+                        "token_count": token_count,
+                    }
+                    chunk_file.write(
+                        json.dumps(record, ensure_ascii=False) + "\n"
+                    )
+                    total += 1
+        logger.info(
+            f"Exported {total} RAG chunks to JSONL file: {output_path}"
+        )
+        return total
+
+    def export_to_vectors(self, output_path, chunk_size=0, chunk_overlap=0):
+        """
+        Export pages (optionally chunked) to a Parquet file via pyarrow.
+
+        Parquet is the portable deliverable; pushing the rows into a managed
+        vector store is left as a documented follow-up. When ``chunk_size`` is
+        greater than zero, rows are chunk-level
+        ``(url, chunk_index, content, token_count)``; otherwise they are
+        page-level ``(url, content, metadata, token_count)`` where
+        ``token_count`` uses tiktoken if available and a labelled estimate
+        otherwise.
+
+        Args:
+            output_path (str): Destination path for the ``.parquet`` file.
+            chunk_size (int): When ``> 0``, emit token-aware chunk rows
+                (requires the ``rag`` extra). Defaults to ``0`` (page rows).
+            chunk_overlap (int): Tokens shared between consecutive chunks when
+                chunking is enabled.
+
+        Returns:
+            int: The number of rows written.
+
+        Raises:
+            ImportError: If the ``vector`` extra (pyarrow) is not installed, or
+                the ``rag`` extra is missing while ``chunk_size > 0``.
+        """
+        try:
+            import pyarrow as pa
+            import pyarrow.parquet as pq
+        except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+            raise ImportError(VECTOR_MISSING_MESSAGE) from exc
+
+        pages = self.db_manager.get_all_pages()
+
+        if chunk_size > 0:
+            encoder = rag.get_encoder()
+            urls, indices, contents, token_counts = [], [], [], []
+            for url, content, _metadata in pages:
+                if content is None:
+                    continue
+                cleaned = self._cleanup_markdown(content)
+                chunks = rag.chunk_text(
+                    cleaned, chunk_size, chunk_overlap, encoder=encoder
+                )
+                for index, (chunk_content, token_count) in enumerate(chunks):
+                    urls.append(url)
+                    indices.append(index)
+                    contents.append(chunk_content)
+                    token_counts.append(token_count)
+            table = pa.table(
+                {
+                    "url": urls,
+                    "chunk_index": indices,
+                    "content": contents,
+                    "token_count": token_counts,
+                }
+            )
+        else:
+            urls, contents, metadatas, token_counts = [], [], [], []
+            for url, content, metadata in pages:
+                if content is None:
+                    continue
+                cleaned = self._cleanup_markdown(content)
+                token_count, _method = rag.estimate_tokens(cleaned)
+                urls.append(url)
+                contents.append(cleaned)
+                metadatas.append(metadata or "{}")
+                token_counts.append(token_count)
+            table = pa.table(
+                {
+                    "url": urls,
+                    "content": contents,
+                    "metadata": metadatas,
+                    "token_count": token_counts,
+                }
+            )
+
+        pq.write_table(table, output_path)
+        logger.info(
+            f"Exported {table.num_rows} rows to Parquet file: {output_path}"
+        )
+        return table.num_rows
+
+    def compute_token_totals(self):
+        """
+        Compute total token usage across the whole crawled corpus.
+
+        Uses tiktoken for an exact count when the ``rag`` extra is installed,
+        otherwise a clearly labelled word-based estimate so the figure is still
+        meaningful on a bare installation.
+
+        Returns:
+            tuple[int, str, int]: ``(total_tokens, method, page_count)`` where
+            ``method`` is ``"tiktoken"`` or ``"word-estimate"`` and
+            ``page_count`` counts the non-empty pages measured.
+        """
+        pages = self.db_manager.get_all_pages()
+        total_tokens = 0
+        method = "tiktoken"
+        page_count = 0
+        for _url, content, _metadata in pages:
+            if content is None:
+                continue
+            tokens, method = rag.estimate_tokens(content)
+            total_tokens += tokens
+            page_count += 1
+        return total_tokens, method, page_count

--- a/crawler_to_md/mcp_server.py
+++ b/crawler_to_md/mcp_server.py
@@ -1,0 +1,139 @@
+"""MCP (Model Context Protocol) server exposing crawler-to-md as tools.
+
+The server exposes two tools over stdio:
+
+* ``crawl`` — crawl a site (or single page) and return the structured pages
+  plus run statistics.
+* ``fetch_as_markdown`` — fetch a single URL and return its Markdown content.
+
+The official MCP Python SDK is an **optional** dependency (the ``mcp`` extra).
+This module is importable without it: the SDK is imported lazily and a clear,
+actionable error is raised only when the server is actually constructed. The
+underlying tool logic lives in plain callables (:func:`crawl_tool` and
+:func:`fetch_as_markdown`) so it can be tested without the SDK installed.
+"""
+
+import logging
+from typing import Any, Optional
+
+from . import crawl
+from .core import CrawlResult
+
+logger = logging.getLogger(__name__)
+
+# Actionable error shown when the MCP server is constructed without the
+# optional ``mcp`` extra installed.
+MCP_MISSING_MESSAGE = (
+    "The MCP server requires the optional 'mcp' extra. "
+    "Install it with: pip install crawler-to-md[mcp]"
+)
+
+
+def _import_fastmcp():
+    """Lazily import the MCP SDK's ``FastMCP`` server class.
+
+    Returns:
+        type: The ``mcp.server.fastmcp.FastMCP`` class.
+
+    Raises:
+        RuntimeError: If the optional ``mcp`` extra is not installed, with a
+            message explaining how to install it.
+    """
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise RuntimeError(MCP_MISSING_MESSAGE) from exc
+    return FastMCP
+
+
+def crawl_tool(url: str, options: Optional[dict] = None) -> dict:
+    """Crawl ``url`` and return a JSON-serialisable summary of the result.
+
+    Args:
+        url (str): The base URL to crawl.
+        options (dict | None): Optional keyword overrides forwarded to
+            :func:`crawler_to_md.crawl` (e.g. ``max_pages``, ``max_depth``,
+            ``concurrency``, ``include_url``).
+
+    Returns:
+        dict: ``{"pages": [...], "stats": {...}}`` where ``pages`` is the list
+        of ``{"url", "content", "metadata"}`` records and ``stats`` is the
+        aggregate run statistics.
+    """
+    result: CrawlResult = crawl(url, **(options or {}))
+    return {
+        "pages": result.pages,
+        "stats": {
+            "links_discovered": result.stats.links_discovered,
+            "pages_scraped": result.stats.pages_scraped,
+            "pages_stored": result.stats.pages_stored,
+            "content_bytes": result.stats.content_bytes,
+            "total_tokens": result.stats.total_tokens,
+            "token_method": result.stats.token_method,
+            "duration": result.stats.duration,
+        },
+    }
+
+
+def fetch_as_markdown(url: str, options: Optional[dict] = None) -> str:
+    """Fetch a single URL and return its Markdown content.
+
+    No link discovery is performed: the crawl is bounded to one page at depth
+    zero so only ``url`` itself is fetched and converted.
+
+    Args:
+        url (str): The URL to fetch and convert.
+        options (dict | None): Optional keyword overrides forwarded to
+            :func:`crawler_to_md.crawl` (e.g. ``timeout``, ``user_agent``,
+            ``render``).
+
+    Returns:
+        str: The Markdown content of the page.
+
+    Raises:
+        RuntimeError: If no content could be fetched from ``url``.
+    """
+    opts: dict[str, Any] = dict(options or {})
+    opts.setdefault("max_pages", 1)
+    opts.setdefault("max_depth", 0)
+    result: CrawlResult = crawl(url, **opts)
+    for page in result.pages:
+        if page.get("content"):
+            return page["content"]
+    raise RuntimeError(f"No content could be fetched from {url}")
+
+
+def build_server():
+    """Construct the MCP server with the ``crawl`` and ``fetch_as_markdown`` tools.
+
+    Returns:
+        FastMCP: A configured MCP server instance ready to ``run()``.
+
+    Raises:
+        RuntimeError: If the optional ``mcp`` extra is not installed.
+    """
+    fast_mcp = _import_fastmcp()
+    server = fast_mcp("crawler-to-md")
+
+    @server.tool()
+    def crawl(url: str, options: Optional[dict] = None) -> dict:
+        """Crawl a site or page and return its pages and run statistics."""
+        return crawl_tool(url, options)
+
+    @server.tool(name="fetch_as_markdown")
+    def fetch(url: str, options: Optional[dict] = None) -> str:
+        """Fetch a single URL and return its Markdown content."""
+        return fetch_as_markdown(url, options)
+
+    return server
+
+
+def serve() -> None:
+    """Build and run the MCP server over stdio (blocking).
+
+    Raises:
+        RuntimeError: If the optional ``mcp`` extra is not installed.
+    """
+    server = build_server()
+    logger.info("Starting crawler-to-md MCP server over stdio")
+    server.run()

--- a/crawler_to_md/plugins.py
+++ b/crawler_to_md/plugins.py
@@ -1,0 +1,637 @@
+"""
+Entry-point-based plugin architecture for crawler-to-md.
+
+This module defines the four pipeline-stage protocols — :class:`Fetcher`,
+:class:`Filter`, :class:`Processor` and :class:`Formatter` — together with a
+defensive :class:`PluginRegistry` that discovers implementations through Python
+`entry points <https://packaging.python.org/en/latest/specifications/entry-points/>`_.
+
+Design goals
+------------
+* **Zero behaviour change.** First-party implementations *wrap* the proven
+  :class:`~crawler_to_md.export_manager.ExportManager` and
+  :class:`~crawler_to_md.scraper.Scraper` logic rather than reimplementing it,
+  so re-expressing a feature through the registry produces byte-identical
+  output.
+* **Always available.** Each group ships built-in first-party implementations
+  that the registry exposes even before the distribution metadata is refreshed.
+  Installed entry points (declared in ``pyproject.toml`` and contributed by
+  third parties) are merged on top, so discovery never depends on install
+  timing.
+* **Defensive discovery.** Entry-point resolution tolerates zero installed
+  plugins, never raises at import time, skips individual broken plugins with a
+  warning, and caches its results.
+
+Entry-point groups
+-------------------
+* ``crawler_to_md.formatters`` → :class:`Formatter`
+* ``crawler_to_md.filters`` → :class:`Filter`
+* ``crawler_to_md.processors`` → :class:`Processor`
+* ``crawler_to_md.fetchers`` → :class:`Fetcher`
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib.metadata import entry_points
+from types import MappingProxyType
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# Mapping of short group key (used throughout the API) to the fully-qualified
+# entry-point group name declared in ``pyproject.toml``.
+GROUPS = MappingProxyType(
+    {
+        "formatters": "crawler_to_md.formatters",
+        "filters": "crawler_to_md.filters",
+        "processors": "crawler_to_md.processors",
+        "fetchers": "crawler_to_md.fetchers",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Protocols
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class Formatter(Protocol):
+    """
+    Render the crawled corpus into an on-disk export.
+
+    A formatter is the unit of the ``crawler_to_md.formatters`` group. It is
+    handed the live :class:`~crawler_to_md.export_manager.ExportManager` (which
+    owns the database connection and run title) and an output path, and is free
+    to write one or more files.
+
+    Attributes
+    ----------
+    name : str
+        Stable, unique identifier used to look the formatter up in the registry
+        and to declare its entry point.
+    """
+
+    name: str
+
+    def export(self, manager: Any, output_path: str, **options: Any) -> Any:
+        """
+        Write the corpus to ``output_path``.
+
+        Parameters
+        ----------
+        manager : crawler_to_md.export_manager.ExportManager
+            The export manager providing the database accessor and run title.
+        output_path : str
+            Destination path or folder, depending on the formatter.
+        **options : Any
+            Formatter-specific keyword options (e.g. ``base_url``,
+            ``frontmatter``, ``chunk_size``).
+
+        Returns
+        -------
+        Any
+            Whatever the underlying export produces (often ``None`` or a path).
+        """
+        ...
+
+
+@runtime_checkable
+class Filter(Protocol):
+    """
+    Decide whether a discovered URL belongs in the crawl frontier.
+
+    A filter is the unit of the ``crawler_to_md.filters`` group.
+
+    Attributes
+    ----------
+    name : str
+        Stable, unique identifier used for registry lookup and entry points.
+    """
+
+    name: str
+
+    def is_allowed(self, url: str) -> bool:
+        """
+        Return whether ``url`` should be crawled.
+
+        Parameters
+        ----------
+        url : str
+            The candidate URL.
+
+        Returns
+        -------
+        bool
+            ``True`` if the URL passes the filter, ``False`` to drop it.
+        """
+        ...
+
+
+@runtime_checkable
+class Processor(Protocol):
+    """
+    Transform a page's HTML before Markdown conversion.
+
+    A processor is the unit of the ``crawler_to_md.processors`` group.
+
+    Attributes
+    ----------
+    name : str
+        Stable, unique identifier used for registry lookup and entry points.
+    """
+
+    name: str
+
+    def process(self, html: str, url: str) -> str:
+        """
+        Return the transformed HTML for ``url``.
+
+        Parameters
+        ----------
+        html : str
+            The raw HTML of the page.
+        url : str
+            The source URL (available for context-aware processing).
+
+        Returns
+        -------
+        str
+            The (possibly) transformed HTML.
+        """
+        ...
+
+
+@runtime_checkable
+class Fetcher(Protocol):
+    """
+    Retrieve a URL and return a response-like object.
+
+    A fetcher is the unit of the ``crawler_to_md.fetchers`` group. The returned
+    object is expected to expose the small ``requests``/``httpx`` response
+    surface consumed by the crawl loop (``status_code``, ``headers``, ``text``,
+    ``content``).
+
+    Attributes
+    ----------
+    name : str
+        Stable, unique identifier used for registry lookup and entry points.
+    """
+
+    name: str
+
+    def fetch(self, url: str) -> Any:
+        """
+        Fetch ``url`` and return a response-like object.
+
+        Parameters
+        ----------
+        url : str
+            The URL to fetch.
+
+        Returns
+        -------
+        Any
+            A response-like object, or ``None`` on failure.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# First-party formatters (thin wrappers over ExportManager methods)
+# ---------------------------------------------------------------------------
+
+
+class MarkdownFormatter:
+    """Formatter delegating to :meth:`ExportManager.export_to_markdown`."""
+
+    name = "markdown"
+
+    def export(self, manager: Any, output_path: str, **options: Any) -> Any:
+        """Write the concatenated Markdown file to ``output_path``."""
+        return manager.export_to_markdown(output_path)
+
+
+class JsonFormatter:
+    """Formatter delegating to :meth:`ExportManager.export_to_json`."""
+
+    name = "json"
+
+    def export(self, manager: Any, output_path: str, **options: Any) -> Any:
+        """Write the JSON corpus file to ``output_path``."""
+        return manager.export_to_json(output_path)
+
+
+class JsonlFormatter:
+    """Formatter delegating to :meth:`ExportManager.export_to_jsonl`."""
+
+    name = "jsonl"
+
+    def export(self, manager: Any, output_path: str, **options: Any) -> Any:
+        """Write the JSON Lines corpus file to ``output_path``."""
+        return manager.export_to_jsonl(output_path)
+
+
+class LlmsFormatter:
+    """Formatter delegating to :meth:`ExportManager.export_to_llms`."""
+
+    name = "llms"
+
+    def export(self, manager: Any, output_path: str, **options: Any) -> Any:
+        """Write ``llms.txt`` / ``llms-full.txt`` into the ``output_path`` folder."""
+        return manager.export_to_llms(output_path)
+
+
+class IndividualMarkdownFormatter:
+    """Formatter delegating to :meth:`ExportManager.export_individual_markdown`."""
+
+    name = "individual"
+
+    def export(self, manager: Any, output_path: str, **options: Any) -> Any:
+        """
+        Write each page as an individual Markdown file under ``output_path``.
+
+        Recognised options: ``base_url`` (str or ``None``) and ``frontmatter``
+        (bool, default ``True``).
+        """
+        return manager.export_individual_markdown(
+            output_path,
+            base_url=options.get("base_url"),
+            frontmatter=options.get("frontmatter", True),
+        )
+
+
+class ChunksFormatter:
+    """Formatter delegating to :meth:`ExportManager.export_chunks_jsonl`."""
+
+    name = "chunks"
+
+    def export(self, manager: Any, output_path: str, **options: Any) -> Any:
+        """
+        Write token-aware RAG chunks as JSON Lines to ``output_path``.
+
+        Recognised options: ``chunk_size`` (int, required ``> 0``) and
+        ``chunk_overlap`` (int, default ``0``).
+        """
+        return manager.export_chunks_jsonl(
+            output_path,
+            options.get("chunk_size", 0),
+            options.get("chunk_overlap", 0),
+        )
+
+
+class VectorsFormatter:
+    """Formatter delegating to :meth:`ExportManager.export_to_vectors`."""
+
+    name = "vectors"
+
+    def export(self, manager: Any, output_path: str, **options: Any) -> Any:
+        """
+        Write a Parquet vector export to ``output_path``.
+
+        Recognised options: ``chunk_size`` (int, default ``0``) and
+        ``chunk_overlap`` (int, default ``0``).
+        """
+        return manager.export_to_vectors(
+            output_path,
+            options.get("chunk_size", 0),
+            options.get("chunk_overlap", 0),
+        )
+
+
+# ---------------------------------------------------------------------------
+# First-party filter / processor / fetcher
+# ---------------------------------------------------------------------------
+
+
+class UrlPatternFilter:
+    """
+    Include/exclude URL filter mirroring :meth:`Scraper.is_valid_link`.
+
+    The canonical form of each URL is compared so that equivalent URLs
+    (differing only by default port, tracking parameters, query order, ...)
+    are filtered identically to the crawl loop.
+
+    Parameters
+    ----------
+    base_url : str or None, optional
+        If set, a URL must canonically start with the canonical base URL.
+    include_patterns : list[str] or None, optional
+        If non-empty, a URL must contain at least one of these substrings.
+    exclude_patterns : list[str] or None, optional
+        A URL containing any of these substrings is rejected.
+    """
+
+    name = "url-pattern"
+
+    def __init__(self, base_url=None, include_patterns=None, exclude_patterns=None):
+        self.base_url = base_url
+        self.include_patterns = list(include_patterns or [])
+        self.exclude_patterns = list(exclude_patterns or [])
+
+    @classmethod
+    def from_scraper(cls, scraper: Any) -> "UrlPatternFilter":
+        """
+        Build a filter from a configured :class:`Scraper`.
+
+        Parameters
+        ----------
+        scraper : crawler_to_md.scraper.Scraper
+            The scraper whose ``base_url`` and include/exclude patterns are
+            mirrored.
+
+        Returns
+        -------
+        UrlPatternFilter
+            A filter producing the same verdicts as ``scraper.is_valid_link``.
+        """
+        return cls(
+            base_url=scraper.base_url,
+            include_patterns=scraper.include_url_patterns,
+            exclude_patterns=scraper.exclude_patterns,
+        )
+
+    def is_allowed(self, url: str) -> bool:
+        """Return whether ``url`` passes the include/exclude rules."""
+        from . import utils
+
+        canonical = utils.canonicalize_url(url)
+        if self.base_url and not canonical.startswith(
+            utils.canonicalize_url(self.base_url)
+        ):
+            return False
+        if self.include_patterns and not any(
+            pattern in canonical for pattern in self.include_patterns
+        ):
+            return False
+        for pattern in self.exclude_patterns:
+            if pattern in canonical:
+                return False
+        return True
+
+
+class NoOpProcessor:
+    """
+    Pass-through processor that returns the HTML unchanged.
+
+    Serves as the safe default first-party processor: it imposes no
+    transformation, so wiring it into the pipeline cannot alter behaviour.
+    """
+
+    name = "noop"
+
+    def process(self, html: str, url: str) -> str:
+        """Return ``html`` unmodified."""
+        return html
+
+
+class RequestsFetcher:
+    """
+    Fetcher wrapping a ``requests`` session (or an existing scraper).
+
+    Parameters
+    ----------
+    session : requests.Session or None, optional
+        The session used to issue GET requests. A fresh session is created when
+        omitted.
+    timeout : float, optional
+        Per-request timeout in seconds. Defaults to ``15``.
+    """
+
+    name = "requests"
+
+    def __init__(self, session=None, timeout=15):
+        self._session = session
+        self.timeout = timeout
+
+    @property
+    def session(self):
+        """Return the underlying session, creating one lazily if needed."""
+        if self._session is None:
+            import requests
+
+            self._session = requests.Session()
+        return self._session
+
+    @classmethod
+    def from_scraper(cls, scraper: Any) -> "RequestsFetcher":
+        """
+        Build a fetcher that delegates to a scraper's retrying GET.
+
+        Parameters
+        ----------
+        scraper : crawler_to_md.scraper.Scraper
+            The scraper whose ``_get_with_retry`` (retry/backoff, timeout,
+            headers/auth) is reused verbatim.
+
+        Returns
+        -------
+        RequestsFetcher
+            A fetcher whose :meth:`fetch` calls ``scraper._get_with_retry``.
+        """
+        fetcher = cls(session=scraper.session, timeout=scraper.timeout)
+        fetcher._scraper = scraper
+        return fetcher
+
+    def fetch(self, url: str) -> Any:
+        """
+        Fetch ``url`` and return the response.
+
+        When built via :meth:`from_scraper`, delegates to the scraper's
+        retry-aware GET; otherwise issues a single GET with the session.
+        """
+        scraper = getattr(self, "_scraper", None)
+        if scraper is not None:
+            return scraper._get_with_retry(url)
+        return self.session.get(url, timeout=self.timeout)
+
+
+# Built-in first-party implementations, keyed by group then by ``name``. These
+# are always available through the registry; installed entry points are merged
+# on top so discovery never depends on the distribution metadata being fresh.
+_BUILTINS: dict[str, dict[str, Any]] = {
+    "formatters": {
+        cls.name: cls
+        for cls in (
+            MarkdownFormatter,
+            JsonFormatter,
+            JsonlFormatter,
+            LlmsFormatter,
+            IndividualMarkdownFormatter,
+            ChunksFormatter,
+            VectorsFormatter,
+        )
+    },
+    "filters": {UrlPatternFilter.name: UrlPatternFilter},
+    "processors": {NoOpProcessor.name: NoOpProcessor},
+    "fetchers": {RequestsFetcher.name: RequestsFetcher},
+}
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class PluginRegistry:
+    """
+    Discover and cache pipeline plugins from built-ins and entry points.
+
+    For each group the registry exposes the built-in first-party
+    implementations merged with any entry-point-contributed plugins. Discovery
+    is defensive: a missing distribution, an absent group, or an individual
+    plugin that fails to import never raises — it is logged and skipped.
+    Results are cached per group until :meth:`clear_cache` is called.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, dict[str, Any]] = {}
+
+    def clear_cache(self) -> None:
+        """Drop all cached discovery results (forces a fresh re-scan)."""
+        self._cache.clear()
+
+    @staticmethod
+    def _load_entry_points(group_path: str) -> dict[str, Any]:
+        """
+        Load every entry point in ``group_path`` defensively.
+
+        Parameters
+        ----------
+        group_path : str
+            Fully-qualified entry-point group name.
+
+        Returns
+        -------
+        dict[str, Any]
+            Mapping of entry-point name to the loaded object. Broken plugins
+            are skipped with a warning; a missing group yields an empty dict.
+        """
+        result: dict[str, Any] = {}
+        try:
+            discovered = entry_points(group=group_path)
+        except Exception as exc:  # pragma: no cover - importlib edge cases
+            logger.warning("Entry-point discovery failed for %s: %s", group_path, exc)
+            return result
+        for ep in discovered:
+            try:
+                result[ep.name] = ep.load()
+            except Exception as exc:
+                logger.warning(
+                    "Skipping plugin %r in group %s: %s", ep.name, group_path, exc
+                )
+        return result
+
+    def discover(self, group: str, *, refresh: bool = False) -> dict[str, Any]:
+        """
+        Return all plugins for ``group`` (built-ins merged with entry points).
+
+        Parameters
+        ----------
+        group : str
+            Short group key (one of :data:`GROUPS`, e.g. ``"formatters"``).
+        refresh : bool, optional
+            When ``True``, bypass and rebuild the cache for this group.
+
+        Returns
+        -------
+        dict[str, Any]
+            Mapping of plugin name to the loaded object/class. Entry points
+            override built-ins of the same name.
+
+        Raises
+        ------
+        KeyError
+            If ``group`` is not a recognised group key.
+        """
+        if group not in GROUPS:
+            raise KeyError(f"Unknown plugin group: {group!r}")
+        if refresh or group not in self._cache:
+            merged = dict(_BUILTINS.get(group, {}))
+            merged.update(self._load_entry_points(GROUPS[group]))
+            self._cache[group] = merged
+        return dict(self._cache[group])
+
+    def names(self, group: str) -> list[str]:
+        """
+        Return the sorted plugin names available for ``group``.
+
+        Parameters
+        ----------
+        group : str
+            Short group key.
+
+        Returns
+        -------
+        list[str]
+            Sorted plugin names.
+        """
+        return sorted(self.discover(group))
+
+    def get(self, group: str, name: str) -> Any:
+        """
+        Return the plugin object/class registered under ``name`` in ``group``.
+
+        Parameters
+        ----------
+        group : str
+            Short group key.
+        name : str
+            Plugin name.
+
+        Returns
+        -------
+        Any
+            The loaded plugin object/class, or ``None`` if no such plugin
+            exists.
+        """
+        return self.discover(group).get(name)
+
+    def create(self, group: str, name: str, *args: Any, **kwargs: Any) -> Any:
+        """
+        Return a ready-to-use plugin instance for ``name`` in ``group``.
+
+        Classes are instantiated with ``*args``/``**kwargs``; objects that are
+        already instances are returned as-is.
+
+        Parameters
+        ----------
+        group : str
+            Short group key.
+        name : str
+            Plugin name.
+        *args, **kwargs : Any
+            Constructor arguments forwarded when the plugin is a class.
+
+        Returns
+        -------
+        Any
+            A plugin instance.
+
+        Raises
+        ------
+        KeyError
+            If no plugin named ``name`` exists in ``group``.
+        """
+        obj = self.get(group, name)
+        if obj is None:
+            raise KeyError(f"No {group} plugin named {name!r}")
+        return obj(*args, **kwargs) if isinstance(obj, type) else obj
+
+
+# Process-wide default registry. Importing this module never triggers discovery
+# (the registry scans lazily on first use), so import stays side-effect free.
+registry = PluginRegistry()
+
+
+def get_registry() -> PluginRegistry:
+    """
+    Return the process-wide default :class:`PluginRegistry`.
+
+    Returns
+    -------
+    PluginRegistry
+        The shared registry instance.
+    """
+    return registry

--- a/crawler_to_md/rag.py
+++ b/crawler_to_md/rag.py
@@ -1,0 +1,178 @@
+"""
+Token accounting and RAG-oriented text chunking helpers.
+
+This module isolates the optional ``tiktoken`` dependency so that the core
+package stays importable without it. Token-aware chunking (used by the RAG
+chunk export) requires the ``rag`` extra and fails with a clear, actionable
+message when it is missing. Token *estimation* degrades gracefully to a
+cheap word-based heuristic when ``tiktoken`` is unavailable, which keeps the
+run summary useful for bare installations.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Default tiktoken encoding. ``cl100k_base`` is shared by the GPT-3.5/4 family
+# and is a sensible, model-agnostic default for token accounting.
+DEFAULT_ENCODING = "cl100k_base"
+
+# Heuristic ratio of tokens per whitespace-delimited word, used only when
+# ``tiktoken`` is not installed. Deliberately conservative and clearly labelled
+# wherever it surfaces so callers never mistake it for an exact count.
+_WORD_TO_TOKEN_RATIO = 1.3
+
+# Actionable error shown when a tiktoken-only feature is used without the extra.
+RAG_MISSING_MESSAGE = (
+    "Token-aware chunking requires the optional 'rag' extra. "
+    "Install it with: pip install crawler-to-md[rag]"
+)
+
+
+def _load_tiktoken():
+    """
+    Import :mod:`tiktoken`, raising a clear error if the extra is missing.
+
+    Returns
+    -------
+    module
+        The imported :mod:`tiktoken` module.
+
+    Raises
+    ------
+    ImportError
+        If :mod:`tiktoken` is not installed, with a message telling the user
+        to install the ``rag`` extra.
+    """
+    try:
+        import tiktoken
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(RAG_MISSING_MESSAGE) from exc
+    return tiktoken
+
+
+def get_encoder(encoding_name=DEFAULT_ENCODING):
+    """
+    Return a tiktoken encoder for ``encoding_name``.
+
+    Parameters
+    ----------
+    encoding_name : str, optional
+        Name of the tiktoken encoding to load. Defaults to
+        :data:`DEFAULT_ENCODING`.
+
+    Returns
+    -------
+    tiktoken.Encoding
+        The requested encoder.
+
+    Raises
+    ------
+    ImportError
+        If the ``rag`` extra (tiktoken) is not installed.
+    """
+    tiktoken = _load_tiktoken()
+    return tiktoken.get_encoding(encoding_name)
+
+
+def count_tokens(text, encoder=None):
+    """
+    Count tokens in ``text`` exactly using tiktoken.
+
+    Parameters
+    ----------
+    text : str or None
+        The text to tokenize. ``None`` is treated as an empty string.
+    encoder : tiktoken.Encoding, optional
+        A pre-built encoder to reuse. When omitted, the default encoder is
+        created on demand.
+
+    Returns
+    -------
+    int
+        The number of tokens in ``text``.
+
+    Raises
+    ------
+    ImportError
+        If the ``rag`` extra (tiktoken) is not installed.
+    """
+    encoder = encoder or get_encoder()
+    return len(encoder.encode(text or ""))
+
+
+def estimate_tokens(text):
+    """
+    Estimate the token count of ``text``, degrading gracefully.
+
+    Uses tiktoken for an exact count when available; otherwise falls back to a
+    cheap word-based heuristic so the run summary remains useful on bare
+    installations.
+
+    Parameters
+    ----------
+    text : str or None
+        The text to measure. ``None`` is treated as an empty string.
+
+    Returns
+    -------
+    tuple[int, str]
+        A ``(count, method)`` pair where ``method`` is ``"tiktoken"`` for an
+        exact count or ``"word-estimate"`` for the heuristic fallback.
+    """
+    text = text or ""
+    try:
+        encoder = get_encoder()
+    except ImportError:
+        words = len(text.split())
+        return int(round(words * _WORD_TO_TOKEN_RATIO)), "word-estimate"
+    return len(encoder.encode(text)), "tiktoken"
+
+
+def chunk_text(text, chunk_size, chunk_overlap=0, encoder=None):
+    """
+    Split ``text`` into token-aware, optionally overlapping chunks.
+
+    Parameters
+    ----------
+    text : str or None
+        The text to split. ``None`` is treated as an empty string.
+    chunk_size : int
+        Maximum number of tokens per chunk. Values ``<= 0`` disable chunking
+        and yield an empty list.
+    chunk_overlap : int, optional
+        Number of tokens shared between consecutive chunks. Clamped to the
+        range ``[0, chunk_size - 1]`` so the window always advances.
+    encoder : tiktoken.Encoding, optional
+        A pre-built encoder to reuse. When omitted, the default encoder is
+        created on demand.
+
+    Returns
+    -------
+    list[tuple[str, int]]
+        A list of ``(chunk_text, token_count)`` pairs in document order.
+
+    Raises
+    ------
+    ImportError
+        If the ``rag`` extra (tiktoken) is not installed.
+    """
+    if chunk_size <= 0:
+        return []
+
+    encoder = encoder or get_encoder()
+    tokens = encoder.encode(text or "")
+    if not tokens:
+        return []
+
+    overlap = max(0, min(chunk_overlap, chunk_size - 1))
+    step = chunk_size - overlap
+
+    chunks = []
+    start = 0
+    total = len(tokens)
+    while start < total:
+        window = tokens[start : start + chunk_size]
+        chunks.append((encoder.decode(window), len(window)))
+        start += step
+    return chunks

--- a/crawler_to_md/scraper.py
+++ b/crawler_to_md/scraper.py
@@ -2,8 +2,11 @@ import copy
 import json
 import logging
 import os
+import random
 import tempfile
 import time
+from datetime import datetime
+from email.utils import parsedate_to_datetime
 from urllib.parse import urldefrag, urljoin
 
 import requests
@@ -11,9 +14,17 @@ from bs4 import BeautifulSoup, Tag
 from markitdown import MarkItDown
 from tqdm import tqdm
 
+from . import utils
 from .database_manager import DatabaseManager
 
 logger = logging.getLogger(__name__)
+
+# HTTP status codes that warrant a retry with backoff (rate limiting and
+# transient server errors).
+_RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+
+# Upper bound for a single backoff sleep, in seconds, to avoid pathological waits.
+_MAX_BACKOFF = 30.0
 
 
 class Scraper:
@@ -29,6 +40,10 @@ class Scraper:
         include_filters=None,
         exclude_filters=None,
         timeout=15,
+        max_retries=3,
+        max_pages=0,
+        max_depth=-1,
+        max_time=0,
     ):
         """
         Initialize the Scraper object and log the initialization process.
@@ -48,6 +63,15 @@ class Scraper:
                 of elements to exclude before Markdown conversion.
             timeout (float, optional): Timeout in seconds applied to every HTTP
                 request issued by the scraper. Defaults to ``15``.
+            max_retries (int, optional): Maximum number of retries on transient
+                failures (connection/timeout errors, HTTP 429 and 5xx) before
+                giving up on a URL. Defaults to ``3``.
+            max_pages (int, optional): Maximum number of pages to scrape;
+                ``0`` means unlimited. Defaults to ``0``.
+            max_depth (int, optional): Maximum crawl depth for link discovery;
+                ``-1`` means unlimited. Seeds are depth 0. Defaults to ``-1``.
+            max_time (float, optional): Maximum wall-clock time for the crawl in
+                seconds; ``0`` means unlimited. Defaults to ``0``.
 
         Raises:
             ValueError: If a proxy is provided but unreachable.
@@ -60,6 +84,10 @@ class Scraper:
         self.rate_limit = rate_limit
         self.delay = delay
         self.timeout = timeout
+        self.max_retries = max_retries
+        self.max_pages = max_pages
+        self.max_depth = max_depth
+        self.max_time = max_time
         self.session = requests.Session()
         if proxy:
             self.session.proxies.update({"http": proxy, "https": proxy})
@@ -82,6 +110,117 @@ class Scraper:
             self.session.head(self.base_url, timeout=self.timeout)
         except requests.RequestException as exc:
             raise ValueError(f"Proxy unreachable: {exc}") from exc
+
+    def _backoff_delay(self, attempt):
+        """
+        Compute an exponential backoff delay with jitter for a retry attempt.
+
+        Args:
+            attempt (int): Zero-based index of the failed attempt.
+
+        Returns:
+            float: Delay in seconds, capped at :data:`_MAX_BACKOFF`, with a
+            small random jitter added to avoid thundering-herd retries.
+        """
+        base = min(_MAX_BACKOFF, 0.5 * (2 ** attempt))
+        jitter = random.uniform(0, base * 0.1)
+        return base + jitter
+
+    def _retry_after(self, response):
+        """
+        Parse the ``Retry-After`` header of a response into a delay in seconds.
+
+        Supports both the integer-seconds and HTTP-date forms of the header.
+
+        Args:
+            response (requests.Response): The HTTP response to inspect.
+
+        Returns:
+            float | None: The requested delay in seconds (never negative), or
+            ``None`` if the header is absent or unparseable.
+        """
+        value = response.headers.get("Retry-After")
+        if not value:
+            return None
+        try:
+            return max(0.0, float(value))
+        except (TypeError, ValueError):
+            pass
+        try:
+            retry_dt = parsedate_to_datetime(value)
+            now = datetime.now(retry_dt.tzinfo)
+            return max(0.0, (retry_dt - now).total_seconds())
+        except (TypeError, ValueError):
+            return None
+
+    def _get_with_retry(self, url):
+        """
+        Perform a GET request for ``url`` with retry and exponential backoff.
+
+        Transient connection/timeout errors and retryable HTTP statuses
+        (429 and 5xx, see :data:`_RETRYABLE_STATUS`) trigger a retry, honoring
+        the ``Retry-After`` header when present. The link is *not* marked as
+        visited here; callers decide what to do with the final response once
+        retries are exhausted.
+
+        Args:
+            url (str): The URL to fetch.
+
+        Returns:
+            requests.Response | None: The final response. If every attempt
+            failed with a retryable status, the last response is returned so
+            the caller can inspect its status code.
+
+        Raises:
+            requests.RequestException: If a connection/timeout error persists
+            after the final attempt.
+        """
+        last_response = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = self.session.get(url, timeout=self.timeout)
+            except requests.RequestException as exc:
+                if attempt >= self.max_retries:
+                    logger.warning(
+                        "Giving up on %s after %d attempt(s): %s",
+                        url,
+                        attempt + 1,
+                        exc,
+                    )
+                    raise
+                wait = self._backoff_delay(attempt)
+                logger.debug(
+                    "Connection error for %s (attempt %d/%d): %s; retrying in "
+                    "%.2fs",
+                    url,
+                    attempt + 1,
+                    self.max_retries + 1,
+                    exc,
+                    wait,
+                )
+                time.sleep(wait)
+                continue
+
+            if response.status_code in _RETRYABLE_STATUS and attempt < self.max_retries:
+                wait = self._retry_after(response)
+                if wait is None:
+                    wait = self._backoff_delay(attempt)
+                logger.debug(
+                    "Retryable status %d for %s (attempt %d/%d); retrying in "
+                    "%.2fs",
+                    response.status_code,
+                    url,
+                    attempt + 1,
+                    self.max_retries + 1,
+                    wait,
+                )
+                last_response = response
+                time.sleep(wait)
+                continue
+
+            return response
+
+        return last_response
 
     def _find_elements(self, soup: BeautifulSoup, selector: str):
         """
@@ -112,15 +251,20 @@ class Scraper:
         Returns:
             bool: True if the link is valid, False otherwise.
         """
+        # Compare canonical forms so that equivalent URLs (differing only by
+        # default port, tracking params, query order, etc.) validate identically.
+        canonical = utils.canonicalize_url(link)
         valid = True
-        if self.base_url and not link.startswith(self.base_url):
+        if self.base_url and not canonical.startswith(
+            utils.canonicalize_url(self.base_url)
+        ):
             valid = False
         if self.include_url_patterns and not any(
-            pattern in link for pattern in self.include_url_patterns
+            pattern in canonical for pattern in self.include_url_patterns
         ):
             valid = False
         for pattern in self.exclude_patterns:
-            if pattern in link:
+            if pattern in canonical:
                 valid = False
         logger.debug(f"Link validation for {link}: {valid}")
         return valid
@@ -140,11 +284,12 @@ class Scraper:
         logger.debug(f"Fetching links from {url}")
         try:
             if not html:
-                # Send a GET request to the URL
-                response = self.session.get(url, timeout=self.timeout)
-                if response.status_code != 200:
+                # Send a GET request to the URL, retrying on transient failures.
+                response = self._get_with_retry(url)
+                if response is None or response.status_code != 200:
+                    status = response.status_code if response is not None else "none"
                     logger.warning(
-                        f"Failed to fetch {url} with status code {response.status_code}"
+                        f"Failed to fetch {url} with status code {status}"
                     )
                     return []
                 else:
@@ -258,7 +403,7 @@ class Scraper:
             url (str, optional): A single URL to start scraping from. Defaults to None.
             urls_list (list, optional): A list of URLs to scrape.
         """
-        # Validate and insert the provided URLs into the database
+        # Validate, canonicalize, and seed the provided URLs at depth 0.
         urls = urls_list or []
         if urls:
             # Build a new list of valid URLs without modifying the original list
@@ -267,13 +412,13 @@ class Scraper:
                 if not self.is_valid_link(url_item):
                     logger.warning(f"Skipping invalid URL: {url_item}")
                     continue
-                validated_urls.append(url_item)
+                validated_urls.append(utils.canonicalize_url(url_item))
 
             # Insert the validated list of URLs into the database
-            self.db_manager.insert_link(validated_urls)
+            self.db_manager.insert_link(validated_urls, depth=0)
         elif url:
-            # Insert a single URL if provided and valid
-            self.db_manager.insert_link(url)
+            # Insert a single canonicalized URL if provided
+            self.db_manager.insert_link(utils.canonicalize_url(url), depth=0)
 
         # Log the start of the scraping process
         logger.info("Starting scraping process")
@@ -286,9 +431,12 @@ class Scraper:
             unit="link",
         )
 
-        # Initialize rate limit tracking variables
+        # Rate-limit and crawl-bound tracking state.
         request_count = 0
         start_time = time.time()
+        crawl_start = time.time()
+        scraped_count = 0
+        stop = False
 
         # Begin the scraping loop
         while True:
@@ -302,6 +450,23 @@ class Scraper:
 
             # Process each unvisited link
             for link in unvisited_links:
+                # Enforce crawl bounds before issuing any further request.
+                if self.max_pages > 0 and scraped_count >= self.max_pages:
+                    logger.info(
+                        "Reached max pages (%d). Stopping crawl.", self.max_pages
+                    )
+                    stop = True
+                    break
+                if (
+                    self.max_time > 0
+                    and (time.time() - crawl_start) >= self.max_time
+                ):
+                    logger.info(
+                        "Reached max time (%.0fs). Stopping crawl.", self.max_time
+                    )
+                    stop = True
+                    break
+
                 # Check rate limit
                 if self.rate_limit > 0:
                     current_time = time.time()
@@ -326,12 +491,13 @@ class Scraper:
 
                 pbar.update(1)  # Update the progress bar
                 url = link[0]  # Extract the URL from the link tuple
+                depth = link[1] if len(link) > 1 else 0  # Crawl depth of the link
 
-                # Attempt to fetch the page content. Network failures must not
-                # crash the crawl loop: log, mark the link visited so it is not
-                # retried indefinitely, and move on to the next link.
+                # Attempt to fetch the page content with retry/backoff. Network
+                # failures that survive all retries must not crash the crawl
+                # loop: log, mark visited, and move on to the next link.
                 try:
-                    response = self.session.get(url, timeout=self.timeout)
+                    response = self._get_with_retry(url)
                 except requests.RequestException as exc:
                     logger.warning("Failed to fetch %s: %s", url, exc)
                     self.db_manager.mark_link_visited(url)
@@ -340,10 +506,16 @@ class Scraper:
                 # Increment request count for rate limiting
                 request_count += 1
 
-                # Check for a successful response and correct content type
-                if response.status_code != 200 or not response.headers.get(
-                    "content-type", ""
-                ).startswith("text/html"):
+                # Check for a successful response and correct content type. A
+                # retryable status that survived all retries lands here and is
+                # only now marked visited (not before retries were exhausted).
+                if (
+                    response is None
+                    or response.status_code != 200
+                    or not response.headers.get("content-type", "").startswith(
+                        "text/html"
+                    )
+                ):
                     # Mark the link as visited and log the reason for skipping
                     self.db_manager.mark_link_visited(url)
                     logger.info(
@@ -360,19 +532,22 @@ class Scraper:
 
                 # Insert the scraped data into the database
                 self.db_manager.insert_page(url, content, json.dumps(metadata))
+                scraped_count += 1
 
-                # Fetch and insert new links found on the page,
-                # if not working from a predefined list
-                if not urls_list:
+                # Fetch and insert new links found on the page, if not working
+                # from a predefined list and still within the depth bound.
+                discover = self.max_depth < 0 or depth < self.max_depth
+                if not urls_list and discover:
                     new_links = self.fetch_links(html=html, url=url)
 
-                    # Count and insert new links into the database
+                    # Count and insert new links into the database at depth+1.
                     real_new_links_count = 0
                     for new_url in new_links:
-                        if self.db_manager.insert_link(new_url):
+                        canonical = utils.canonicalize_url(new_url)
+                        if self.db_manager.insert_link(canonical, depth=depth + 1):
                             real_new_links_count += 1
                             logger.debug(
-                                f"Inserted new link {new_url} into the database"
+                                f"Inserted new link {canonical} into the database"
                             )
 
                     # Update the progress bar total with the count of new links
@@ -382,6 +557,10 @@ class Scraper:
 
                 # Mark the current link as visited in the database
                 self.db_manager.mark_link_visited(url)
+
+            # Break the outer loop too when a crawl bound has been reached.
+            if stop:
+                break
 
         # Close the progress bar upon completion of the scraping process
         pbar.close()

--- a/crawler_to_md/scraper.py
+++ b/crawler_to_md/scraper.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import json
 import logging
@@ -9,6 +10,7 @@ from datetime import datetime
 from email.utils import parsedate_to_datetime
 from urllib.parse import urldefrag, urljoin
 
+import httpx
 import requests
 from bs4 import BeautifulSoup, Tag
 from markitdown import MarkItDown
@@ -44,6 +46,7 @@ class Scraper:
         max_pages=0,
         max_depth=-1,
         max_time=0,
+        concurrency=1,
     ):
         """
         Initialize the Scraper object and log the initialization process.
@@ -72,6 +75,9 @@ class Scraper:
                 ``-1`` means unlimited. Seeds are depth 0. Defaults to ``-1``.
             max_time (float, optional): Maximum wall-clock time for the crawl in
                 seconds; ``0`` means unlimited. Defaults to ``0``.
+            concurrency (int, optional): Number of concurrent fetches for the
+                async crawl path. ``1`` (the default) behaves exactly like the
+                synchronous path; values greater than ``1`` fetch in parallel.
 
         Raises:
             ValueError: If a proxy is provided but unreachable.
@@ -88,6 +94,7 @@ class Scraper:
         self.max_pages = max_pages
         self.max_depth = max_depth
         self.max_time = max_time
+        self.concurrency = max(1, concurrency)
         self.session = requests.Session()
         if proxy:
             self.session.proxies.update({"http": proxy, "https": proxy})
@@ -564,3 +571,282 @@ class Scraper:
 
         # Close the progress bar upon completion of the scraping process
         pbar.close()
+
+    def _make_async_client(self):
+        """
+        Create the ``httpx.AsyncClient`` used by the async crawl path.
+
+        Centralized so tests can monkeypatch it to inject a mock transport.
+        ``follow_redirects=True`` mirrors the redirect-following behavior of the
+        synchronous ``requests`` session.
+
+        Returns:
+            httpx.AsyncClient: A configured async HTTP client.
+        """
+        return httpx.AsyncClient(
+            timeout=self.timeout,
+            follow_redirects=True,
+            proxy=self.proxy,
+        )
+
+    async def _aget_with_retry(self, client, url):
+        """
+        Async counterpart of :meth:`_get_with_retry`, mirroring its contract.
+
+        Retries on transient httpx transport errors and retryable HTTP statuses
+        (429 and 5xx, see :data:`_RETRYABLE_STATUS`) using exponential backoff
+        with jitter, honoring the ``Retry-After`` header. The link is *not*
+        marked visited here.
+
+        Args:
+            client (httpx.AsyncClient): The client used to issue the request.
+            url (str): The URL to fetch.
+
+        Returns:
+            httpx.Response | None: The final response. If every attempt failed
+            with a retryable status, the last response is returned.
+
+        Raises:
+            httpx.RequestError: If a transport error persists after the final
+            attempt.
+        """
+        last_response = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = await client.get(url)
+            except httpx.RequestError as exc:
+                if attempt >= self.max_retries:
+                    logger.warning(
+                        "Giving up on %s after %d attempt(s): %s",
+                        url,
+                        attempt + 1,
+                        exc,
+                    )
+                    raise
+                wait = self._backoff_delay(attempt)
+                logger.debug(
+                    "Connection error for %s (attempt %d/%d): %s; retrying in "
+                    "%.2fs",
+                    url,
+                    attempt + 1,
+                    self.max_retries + 1,
+                    exc,
+                    wait,
+                )
+                await asyncio.sleep(wait)
+                continue
+
+            if response.status_code in _RETRYABLE_STATUS and attempt < self.max_retries:
+                wait = self._retry_after(response)
+                if wait is None:
+                    wait = self._backoff_delay(attempt)
+                logger.debug(
+                    "Retryable status %d for %s (attempt %d/%d); retrying in "
+                    "%.2fs",
+                    response.status_code,
+                    url,
+                    attempt + 1,
+                    self.max_retries + 1,
+                    wait,
+                )
+                last_response = response
+                await asyncio.sleep(wait)
+                continue
+
+            return response
+
+        return last_response
+
+    async def _afetch_one(self, client, url, semaphore):
+        """
+        Fetch a single URL within the concurrency semaphore.
+
+        Honors the configured ``delay`` between requests for politeness. Any
+        persistent transport error is captured and returned rather than raised
+        so a single failure cannot abort the whole batch.
+
+        Args:
+            client (httpx.AsyncClient): The async client.
+            url (str): The URL to fetch.
+            semaphore (asyncio.Semaphore): Bounds the number of in-flight fetches.
+
+        Returns:
+            tuple[str, httpx.Response | None, Exception | None]: ``(url,
+            response, error)`` where exactly one of ``response``/``error`` is set
+            on failure (``error`` set, ``response`` ``None``).
+        """
+        async with semaphore:
+            if self.delay > 0:
+                await asyncio.sleep(self.delay)
+            try:
+                response = await self._aget_with_retry(client, url)
+                return (url, response, None)
+            except httpx.RequestError as exc:
+                return (url, None, exc)
+
+    async def start_scraping_async(self, url=None, urls_list=None):
+        """
+        Asynchronous crawl that fetches concurrently while serializing DB access.
+
+        Behaviorally mirrors :meth:`start_scraping`: identical seeding, canonical
+        dedup, content-type filtering, retry/backoff, crawl bounds
+        (``max_pages``/``max_depth``/``max_time``), rate limiting/delay, and
+        upsert/visited semantics. The frontier is processed in
+        ``concurrency``-sized batches: a batch of the shallowest unvisited links
+        is fetched concurrently, then *every* database read/write is applied
+        serially in this single coroutine so the SQLite connection is never used
+        concurrently. With ``concurrency == 1`` this is equivalent to the
+        synchronous path.
+
+        Args:
+            url (str, optional): A single URL to start scraping from.
+            urls_list (list, optional): A list of URLs to scrape.
+        """
+        # Seed the frontier (serial DB access).
+        urls = urls_list or []
+        if urls:
+            validated_urls = []
+            for url_item in urls:
+                if not self.is_valid_link(url_item):
+                    logger.warning(f"Skipping invalid URL: {url_item}")
+                    continue
+                validated_urls.append(utils.canonicalize_url(url_item))
+            self.db_manager.insert_link(validated_urls, depth=0)
+        elif url:
+            self.db_manager.insert_link(utils.canonicalize_url(url), depth=0)
+
+        logger.info(
+            "Starting async scraping process (concurrency=%d)", self.concurrency
+        )
+
+        pbar = tqdm(
+            total=self.db_manager.get_links_count(),
+            initial=self.db_manager.get_visited_links_count(),
+            desc="Scraping",
+            unit="link",
+        )
+
+        # Rate-limit and crawl-bound tracking state.
+        request_count = 0
+        start_time = time.time()
+        crawl_start = time.time()
+        scraped_count = 0
+        stop = False
+
+        semaphore = asyncio.Semaphore(self.concurrency)
+        client = self._make_async_client()
+        try:
+            async with client:
+                while not stop:
+                    # Serial DB read of the current frontier (BFS order).
+                    unvisited_links = self.db_manager.get_unvisited_links()
+                    if not unvisited_links:
+                        logger.info("No more links to visit. Exiting.")
+                        break
+
+                    # Time bound: check before scheduling a new batch.
+                    if (
+                        self.max_time > 0
+                        and (time.time() - crawl_start) >= self.max_time
+                    ):
+                        logger.info(
+                            "Reached max time (%.0fs). Stopping crawl.",
+                            self.max_time,
+                        )
+                        break
+
+                    # Rate limit: enforce the per-minute window before a batch.
+                    if self.rate_limit > 0 and request_count >= self.rate_limit:
+                        elapsed = time.time() - start_time
+                        sleep_time = 60 - elapsed
+                        if sleep_time > 0:
+                            logger.debug(
+                                "Rate limit reached, sleeping for %s seconds",
+                                sleep_time,
+                            )
+                            await asyncio.sleep(sleep_time)
+                        request_count = 0
+                        start_time = time.time()
+
+                    # Take a concurrency-sized batch of the shallowest links.
+                    batch = unvisited_links[: self.concurrency]
+                    depth_by_url = {
+                        link[0]: (link[1] if len(link) > 1 else 0) for link in batch
+                    }
+
+                    # Fetch the batch concurrently (DB untouched here).
+                    results = await asyncio.gather(
+                        *(
+                            self._afetch_one(client, link[0], semaphore)
+                            for link in batch
+                        )
+                    )
+                    request_count += len(results)
+
+                    # Apply every database update serially in this coroutine.
+                    for fetched_url, response, error in results:
+                        pbar.update(1)
+                        depth = depth_by_url.get(fetched_url, 0)
+
+                        # Page bound: stop once enough pages have been scraped.
+                        if self.max_pages > 0 and scraped_count >= self.max_pages:
+                            logger.info(
+                                "Reached max pages (%d). Stopping crawl.",
+                                self.max_pages,
+                            )
+                            stop = True
+                            break
+
+                        # Persistent transport error: mark visited and move on.
+                        if error is not None:
+                            logger.warning(
+                                "Failed to fetch %s: %s", fetched_url, error
+                            )
+                            self.db_manager.mark_link_visited(fetched_url)
+                            continue
+
+                        # Skip non-200 / non-HTML responses (retries exhausted).
+                        if (
+                            response is None
+                            or response.status_code != 200
+                            or not response.headers.get(
+                                "content-type", ""
+                            ).startswith("text/html")
+                        ):
+                            self.db_manager.mark_link_visited(fetched_url)
+                            logger.info(
+                                "Skipping link %s due to invalid status code or "
+                                "content type",
+                                fetched_url,
+                            )
+                            continue
+
+                        html = response.text
+                        content, metadata = self.scrape_page(html, fetched_url)
+                        self.db_manager.insert_page(
+                            fetched_url, content, json.dumps(metadata)
+                        )
+                        scraped_count += 1
+
+                        # Discover new links while within the depth bound.
+                        discover = self.max_depth < 0 or depth < self.max_depth
+                        if not urls_list and discover:
+                            new_links = self.fetch_links(html=html, url=fetched_url)
+                            real_new_links_count = 0
+                            for new_url in new_links:
+                                canonical = utils.canonicalize_url(new_url)
+                                if self.db_manager.insert_link(
+                                    canonical, depth=depth + 1
+                                ):
+                                    real_new_links_count += 1
+                                    logger.debug(
+                                        "Inserted new link %s into the database",
+                                        canonical,
+                                    )
+                            if real_new_links_count:
+                                pbar.total += real_new_links_count
+                                pbar.refresh()
+
+                        self.db_manager.mark_link_visited(fetched_url)
+        finally:
+            pbar.close()

--- a/crawler_to_md/scraper.py
+++ b/crawler_to_md/scraper.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import logging
 import os
 import tempfile
 import time
@@ -10,11 +11,9 @@ from bs4 import BeautifulSoup, Tag
 from markitdown import MarkItDown
 from tqdm import tqdm
 
-from . import log_setup
 from .database_manager import DatabaseManager
 
-logger = log_setup.get_logger()
-logger.name = "Scraper"
+logger = logging.getLogger(__name__)
 
 
 class Scraper:
@@ -29,6 +28,7 @@ class Scraper:
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        timeout=15,
     ):
         """
         Initialize the Scraper object and log the initialization process.
@@ -36,7 +36,8 @@ class Scraper:
         Args:
             base_url (str): The base URL to start scraping from.
             exclude_patterns (list): List of URL patterns to exclude from scraping.
-            include_url_patterns (list): List of URL patterns that must be present to scrape.
+            include_url_patterns (list): List of URL patterns that must be
+                present for a link to be scraped.
             db_manager (DatabaseManager): The database manager object.
             rate_limit (int): Maximum number of requests per minute.
             delay (float): Delay between requests in seconds.
@@ -45,6 +46,8 @@ class Scraper:
                 of elements to include before Markdown conversion.
             exclude_filters (list, optional): CSS-like selectors (#id, .class, tag)
                 of elements to exclude before Markdown conversion.
+            timeout (float, optional): Timeout in seconds applied to every HTTP
+                request issued by the scraper. Defaults to ``15``.
 
         Raises:
             ValueError: If a proxy is provided but unreachable.
@@ -56,6 +59,7 @@ class Scraper:
         self.db_manager = db_manager
         self.rate_limit = rate_limit
         self.delay = delay
+        self.timeout = timeout
         self.session = requests.Session()
         if proxy:
             self.session.proxies.update({"http": proxy, "https": proxy})
@@ -75,7 +79,7 @@ class Scraper:
             ValueError: If the proxy cannot fetch the base URL.
         """
         try:
-            self.session.head(self.base_url, timeout=5)
+            self.session.head(self.base_url, timeout=self.timeout)
         except requests.RequestException as exc:
             raise ValueError(f"Proxy unreachable: {exc}") from exc
 
@@ -137,7 +141,7 @@ class Scraper:
         try:
             if not html:
                 # Send a GET request to the URL
-                response = self.session.get(url)
+                response = self.session.get(url, timeout=self.timeout)
                 if response.status_code != 200:
                     logger.warning(
                         f"Failed to fetch {url} with status code {response.status_code}"
@@ -323,8 +327,15 @@ class Scraper:
                 pbar.update(1)  # Update the progress bar
                 url = link[0]  # Extract the URL from the link tuple
 
-                # Attempt to fetch the page content
-                response = self.session.get(url)
+                # Attempt to fetch the page content. Network failures must not
+                # crash the crawl loop: log, mark the link visited so it is not
+                # retried indefinitely, and move on to the next link.
+                try:
+                    response = self.session.get(url, timeout=self.timeout)
+                except requests.RequestException as exc:
+                    logger.warning("Failed to fetch %s: %s", url, exc)
+                    self.db_manager.mark_link_visited(url)
+                    continue
 
                 # Increment request count for rate limiting
                 request_count += 1

--- a/crawler_to_md/scraper.py
+++ b/crawler_to_md/scraper.py
@@ -2,13 +2,16 @@ import asyncio
 import copy
 import json
 import logging
+import mimetypes
 import os
 import random
 import tempfile
 import time
+import xml.etree.ElementTree as ET
 from datetime import datetime
 from email.utils import parsedate_to_datetime
-from urllib.parse import urldefrag, urljoin
+from urllib import robotparser
+from urllib.parse import urldefrag, urljoin, urlparse
 
 import httpx
 import requests
@@ -27,6 +30,60 @@ _RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
 
 # Upper bound for a single backoff sleep, in seconds, to avoid pathological waits.
 _MAX_BACKOFF = 30.0
+
+# Cap on how many nested sitemap files are followed from a sitemap index, to
+# bound work on pathological or recursive sitemap trees.
+_MAX_SITEMAP_DEPTH = 5
+
+
+def _default_user_agent():
+    """
+    Build the default descriptive User-Agent string for the crawler.
+
+    The version is resolved from the installed package metadata when available,
+    falling back to ``0.0.0`` for editable/unbuilt checkouts.
+
+    Returns:
+        str: A descriptive User-Agent such as
+        ``"crawler-to-md/1.2.3 (+https://github.com/obeone/crawler-to-md)"``.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            package_version = version("crawler-to-md")
+        except PackageNotFoundError:
+            package_version = "0.0.0"
+    except Exception:  # pragma: no cover - importlib always present on 3.10+
+        package_version = "0.0.0"
+    return (
+        f"crawler-to-md/{package_version} "
+        "(+https://github.com/obeone/crawler-to-md)"
+    )
+
+
+class _RenderedResponse:
+    """
+    Minimal response-like wrapper around HTML produced by JS rendering.
+
+    Exposes the small subset of the ``requests``/``httpx`` response interface
+    consumed by the crawl loops (``status_code``, ``headers``, ``text``,
+    ``content``) so rendered pages flow through the same processing path as
+    fetched HTML responses.
+    """
+
+    def __init__(self, html):
+        """
+        Wrap rendered HTML in a response-like object.
+
+        Args:
+            html (str | None): The rendered HTML, or ``None`` if rendering
+                produced no content (treated as a non-success status).
+        """
+        self.status_code = 200 if html is not None else 599
+        self.text = html or ""
+        self.content = (html or "").encode("utf-8")
+        self.headers = {"content-type": "text/html"}
 
 
 class Scraper:
@@ -47,6 +104,15 @@ class Scraper:
         max_depth=-1,
         max_time=0,
         concurrency=1,
+        ignore_robots=False,
+        user_agent=None,
+        sitemap=False,
+        extract="none",
+        render=False,
+        headers=None,
+        cookies=None,
+        auth=None,
+        allow_types=None,
     ):
         """
         Initialize the Scraper object and log the initialization process.
@@ -78,6 +144,32 @@ class Scraper:
             concurrency (int, optional): Number of concurrent fetches for the
                 async crawl path. ``1`` (the default) behaves exactly like the
                 synchronous path; values greater than ``1`` fetch in parallel.
+            ignore_robots (bool, optional): When ``False`` (the default), the
+                crawler honors each host's ``robots.txt`` and skips disallowed
+                URLs. Set ``True`` to ignore robots rules entirely.
+            user_agent (str, optional): User-Agent string sent on every request
+                and used for robots evaluation. Defaults to a descriptive UA
+                built from the package version.
+            sitemap (bool, optional): When ``True``, seed the frontier from the
+                host's ``/sitemap.xml`` (following sitemap indexes) before
+                crawling. Defaults to ``False``.
+            extract ({"none", "readability"}, optional): Content extraction
+                strategy. ``"readability"`` uses ``trafilatura`` (optional
+                ``readability`` extra) to extract the main content before
+                Markdown conversion. Defaults to ``"none"``.
+            render (bool, optional): When ``True``, fetch the JS-rendered HTML
+                via Playwright (optional ``render`` extra) instead of a plain
+                HTTP GET. Defaults to ``False``.
+            headers (list[str] | dict | None, optional): Extra request headers
+                as ``"Key: Value"`` strings (or a mapping). Applied to both the
+                sync session and the async client.
+            cookies (list[str] | dict | None, optional): Cookies as ``"key=value"``
+                strings (or a mapping). Applied to both transports.
+            auth (str | None, optional): HTTP basic-auth credentials as
+                ``"user:pass"``. Applied to both transports.
+            allow_types (list[str] | None, optional): Additional content-type
+                base values (e.g. ``"application/pdf"``) to ingest via MarkItDown
+                in addition to HTML. Links are only discovered from HTML pages.
 
         Raises:
             ValueError: If a proxy is provided but unreachable.
@@ -95,7 +187,33 @@ class Scraper:
         self.max_depth = max_depth
         self.max_time = max_time
         self.concurrency = max(1, concurrency)
+
+        # Crawl-intelligence configuration.
+        self.ignore_robots = ignore_robots
+        self.user_agent = user_agent or _default_user_agent()
+        self.sitemap = sitemap
+        self.extract = extract or "none"
+        self.render = render
+        self.allow_types = {
+            t.split(";")[0].strip().lower() for t in (allow_types or []) if t
+        }
+        # Per-host cache of parsed robots rules (``None`` means "allow all").
+        self._robots_cache = {}
+
+        # Build request headers/cookies/auth shared by both transports. The
+        # descriptive User-Agent is applied first so an explicit ``--header
+        # 'User-Agent: ...'`` can still override it.
+        self._headers = {"User-Agent": self.user_agent}
+        self._headers.update(self._build_headers(headers))
+        self._cookies = self._build_cookies(cookies)
+        self._auth = self._build_auth(auth)
+
         self.session = requests.Session()
+        self.session.headers.update(self._headers)
+        if self._cookies:
+            self.session.cookies.update(self._cookies)
+        if self._auth:
+            self.session.auth = self._auth
         if proxy:
             self.session.proxies.update({"http": proxy, "https": proxy})
         self.proxy = proxy
@@ -105,6 +223,79 @@ class Scraper:
 
         if proxy:
             self._test_proxy()
+
+    @staticmethod
+    def _build_headers(headers):
+        """
+        Normalize the ``headers`` argument into a header dictionary.
+
+        Accepts either a mapping or a list of ``"Key: Value"`` strings. The
+        configured User-Agent is added by the caller; user-supplied headers may
+        override it.
+
+        Args:
+            headers (list[str] | dict | None): Raw header specification.
+
+        Returns:
+            dict[str, str]: The parsed headers (empty dict if none provided).
+        """
+        result = {}
+        if not headers:
+            return result
+        if isinstance(headers, dict):
+            return {str(k): str(v) for k, v in headers.items()}
+        for item in headers:
+            if ":" in item:
+                key, _, value = item.partition(":")
+                result[key.strip()] = value.strip()
+            else:
+                logger.warning("Ignoring malformed header (expected 'K: V'): %s", item)
+        return result
+
+    @staticmethod
+    def _build_cookies(cookies):
+        """
+        Normalize the ``cookies`` argument into a cookie dictionary.
+
+        Accepts either a mapping or a list of ``"key=value"`` strings.
+
+        Args:
+            cookies (list[str] | dict | None): Raw cookie specification.
+
+        Returns:
+            dict[str, str]: The parsed cookies (empty dict if none provided).
+        """
+        result = {}
+        if not cookies:
+            return result
+        if isinstance(cookies, dict):
+            return {str(k): str(v) for k, v in cookies.items()}
+        for item in cookies:
+            if "=" in item:
+                key, _, value = item.partition("=")
+                result[key.strip()] = value.strip()
+            else:
+                logger.warning("Ignoring malformed cookie (expected 'k=v'): %s", item)
+        return result
+
+    @staticmethod
+    def _build_auth(auth):
+        """
+        Normalize the ``auth`` argument into a ``(user, password)`` tuple.
+
+        Args:
+            auth (str | tuple | None): ``"user:pass"`` string or a 2-tuple.
+
+        Returns:
+            tuple[str, str] | None: The credential pair, or ``None`` when no
+            authentication is configured.
+        """
+        if not auth:
+            return None
+        if isinstance(auth, (tuple, list)) and len(auth) == 2:
+            return (str(auth[0]), str(auth[1]))
+        user, _, password = str(auth).partition(":")
+        return (user, password)
 
     def _test_proxy(self):
         """
@@ -276,6 +467,419 @@ class Scraper:
         logger.debug(f"Link validation for {link}: {valid}")
         return valid
 
+    @staticmethod
+    def _robots_host_key(url):
+        """
+        Return the ``scheme://netloc`` key used to cache robots rules per host.
+
+        Args:
+            url (str): Any URL on the target host.
+
+        Returns:
+            str: The origin key (e.g. ``"https://example.com"``).
+        """
+        parsed = urlparse(url)
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+    @staticmethod
+    def _robots_url(url):
+        """
+        Build the ``robots.txt`` URL for the host of ``url``.
+
+        Args:
+            url (str): Any URL on the target host.
+
+        Returns:
+            str: The absolute ``robots.txt`` URL for that host.
+        """
+        parsed = urlparse(url)
+        return f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+
+    def _parser_from_text(self, text):
+        """
+        Build a :class:`urllib.robotparser.RobotFileParser` from rules text.
+
+        Args:
+            text (str): The body of a ``robots.txt`` file.
+
+        Returns:
+            urllib.robotparser.RobotFileParser: A parser primed with the rules.
+        """
+        parser = robotparser.RobotFileParser()
+        parser.parse((text or "").splitlines())
+        return parser
+
+    def _robots_allowed(self, url):
+        """
+        Check whether ``url`` may be fetched according to the host's robots.txt.
+
+        Robots files are fetched once per host through the synchronous session
+        and cached. Any fetch/parse failure or non-200 response is treated as
+        "allow all" (cached as ``None``), matching common crawler behavior.
+
+        Args:
+            url (str): The URL to check.
+
+        Returns:
+            bool: ``True`` if fetching is permitted (or robots is unavailable),
+            ``False`` if the host explicitly disallows ``url``.
+        """
+        key = self._robots_host_key(url)
+        if key not in self._robots_cache:
+            parser = None
+            try:
+                response = self.session.get(
+                    self._robots_url(url), timeout=self.timeout
+                )
+                if response is not None and response.status_code == 200:
+                    parser = self._parser_from_text(response.text)
+            except requests.RequestException as exc:
+                logger.debug("Could not fetch robots.txt for %s: %s", key, exc)
+            self._robots_cache[key] = parser
+        parser = self._robots_cache[key]
+        if parser is None:
+            return True
+        return parser.can_fetch(self.user_agent, url)
+
+    async def _arobots_allowed(self, client, url):
+        """
+        Async counterpart of :meth:`_robots_allowed` using the async client.
+
+        Shares the same per-host cache so robots is fetched at most once per
+        host regardless of which crawl path is active.
+
+        Args:
+            client (httpx.AsyncClient): The async client used to fetch robots.
+            url (str): The URL to check.
+
+        Returns:
+            bool: ``True`` if fetching is permitted, ``False`` otherwise.
+        """
+        key = self._robots_host_key(url)
+        if key not in self._robots_cache:
+            parser = None
+            try:
+                response = await client.get(self._robots_url(url))
+                if response is not None and response.status_code == 200:
+                    parser = self._parser_from_text(response.text)
+            except httpx.RequestError as exc:
+                logger.debug("Could not fetch robots.txt for %s: %s", key, exc)
+            self._robots_cache[key] = parser
+        parser = self._robots_cache[key]
+        if parser is None:
+            return True
+        return parser.can_fetch(self.user_agent, url)
+
+    def _sitemap_base_url(self):
+        """
+        Determine the origin used to locate the default ``sitemap.xml``.
+
+        Returns:
+            str: The ``scheme://netloc`` origin derived from ``base_url``.
+        """
+        parsed = urlparse(self.base_url)
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+    def _collect_sitemap_urls(self, sitemap_url, seen, depth=0):
+        """
+        Recursively collect page URLs from a sitemap or sitemap index.
+
+        Tolerates missing files, non-200/204 responses, empty bodies, and
+        non-XML content by returning an empty list rather than raising.
+
+        Args:
+            sitemap_url (str): URL of the sitemap (or sitemap index) to fetch.
+            seen (set[str]): Set of already-fetched sitemap URLs (cycle guard).
+            depth (int): Current recursion depth into nested sitemap indexes.
+
+        Returns:
+            list[str]: The ``<loc>`` page URLs discovered (deepest-first order
+            is not guaranteed; duplicates are possible and filtered later).
+        """
+        if depth > _MAX_SITEMAP_DEPTH or sitemap_url in seen:
+            return []
+        seen.add(sitemap_url)
+        try:
+            response = self.session.get(sitemap_url, timeout=self.timeout)
+        except requests.RequestException as exc:
+            logger.warning("Sitemap fetch failed for %s: %s", sitemap_url, exc)
+            return []
+        if (
+            response is None
+            or response.status_code != 200
+            or not getattr(response, "content", b"")
+        ):
+            logger.debug("No usable sitemap at %s", sitemap_url)
+            return []
+        try:
+            root = ET.fromstring(response.content)
+        except ET.ParseError as exc:
+            logger.warning("Sitemap parse failed for %s: %s", sitemap_url, exc)
+            return []
+
+        locs = [
+            element.text.strip()
+            for element in root.iter()
+            if element.tag.split("}")[-1].lower() == "loc" and element.text
+        ]
+        root_tag = root.tag.split("}")[-1].lower()
+        if root_tag == "sitemapindex":
+            urls = []
+            for child in locs:
+                urls.extend(self._collect_sitemap_urls(child, seen, depth + 1))
+            return urls
+        return locs
+
+    def _seed_from_sitemap(self):
+        """
+        Seed the crawl frontier from the host's ``sitemap.xml``.
+
+        Discovered URLs are validated via :meth:`is_valid_link`, canonicalized,
+        and inserted at depth 0. Missing or malformed sitemaps are ignored.
+
+        Returns:
+            int: The number of valid URLs seeded from the sitemap.
+        """
+        sitemap_url = urljoin(self._sitemap_base_url() + "/", "sitemap.xml")
+        logger.info("Seeding frontier from sitemap %s", sitemap_url)
+        discovered = self._collect_sitemap_urls(sitemap_url, set())
+        seeded = []
+        for candidate in discovered:
+            if self.is_valid_link(candidate):
+                seeded.append(utils.canonicalize_url(candidate))
+        if seeded:
+            self.db_manager.insert_link(utils.deduplicate_list(seeded), depth=0)
+        logger.info("Seeded %d URL(s) from sitemap", len(seeded))
+        return len(seeded)
+
+    def _import_trafilatura(self):
+        """
+        Lazily import ``trafilatura`` for readability extraction.
+
+        Returns:
+            module: The imported ``trafilatura`` module.
+
+        Raises:
+            RuntimeError: If the optional ``readability`` extra is not installed.
+        """
+        try:
+            import trafilatura
+        except ImportError as exc:
+            raise RuntimeError(
+                "Readability extraction requires the 'readability' extra. "
+                "Install it with: pip install crawler-to-md[readability]"
+            ) from exc
+        return trafilatura
+
+    def _scrape_readability(self, html, url):
+        """
+        Extract the main content of ``html`` as Markdown via ``trafilatura``.
+
+        Args:
+            html (str): The raw HTML of the page.
+            url (str): The source URL (used for logging and metadata).
+
+        Returns:
+            tuple[str | None, dict | None]: ``(markdown, metadata)`` or
+            ``(None, None)`` if no main content could be extracted.
+
+        Raises:
+            RuntimeError: If the optional ``readability`` extra is missing.
+        """
+        trafilatura = self._import_trafilatura()
+        soup = BeautifulSoup(html, "html.parser")
+        title = soup.title.string if soup.title else ""
+        content = trafilatura.extract(
+            html, output_format="markdown", include_comments=False
+        )
+        if not content or not content.strip():
+            logger.warning("Readability extraction produced no content for %s", url)
+            return None, None
+        return content, {"title": title}
+
+    def _render_sync(self, url):
+        """
+        Fetch the JS-rendered HTML of ``url`` using Playwright (sync API).
+
+        Args:
+            url (str): The URL to render.
+
+        Returns:
+            str: The rendered HTML.
+
+        Raises:
+            RuntimeError: If the optional ``render`` extra (or its browsers) is
+            missing, or if rendering fails. The message explains how to install
+            the extra and the browser binaries.
+        """
+        try:
+            from playwright.sync_api import sync_playwright
+        except ImportError as exc:
+            raise RuntimeError(
+                "JS rendering requires the 'render' extra. Install it with: "
+                "pip install crawler-to-md[render]"
+            ) from exc
+        try:
+            with sync_playwright() as playwright:
+                browser = playwright.chromium.launch()
+                try:
+                    page = browser.new_page(user_agent=self.user_agent)
+                    page.goto(url, timeout=self.timeout * 1000)
+                    return page.content()
+                finally:
+                    browser.close()
+        except Exception as exc:
+            raise RuntimeError(
+                f"JS rendering failed for {url}: {exc}. Ensure the Playwright "
+                "browsers are installed (run: playwright install chromium)."
+            ) from exc
+
+    async def _render_async(self, url):
+        """
+        Fetch the JS-rendered HTML of ``url`` using Playwright (async API).
+
+        Args:
+            url (str): The URL to render.
+
+        Returns:
+            str: The rendered HTML.
+
+        Raises:
+            RuntimeError: If the optional ``render`` extra (or its browsers) is
+            missing, or if rendering fails.
+        """
+        try:
+            from playwright.async_api import async_playwright
+        except ImportError as exc:
+            raise RuntimeError(
+                "JS rendering requires the 'render' extra. Install it with: "
+                "pip install crawler-to-md[render]"
+            ) from exc
+        try:
+            async with async_playwright() as playwright:
+                browser = await playwright.chromium.launch()
+                try:
+                    page = await browser.new_page(user_agent=self.user_agent)
+                    await page.goto(url, timeout=self.timeout * 1000)
+                    return await page.content()
+                finally:
+                    await browser.close()
+        except Exception as exc:
+            raise RuntimeError(
+                f"JS rendering failed for {url}: {exc}. Ensure the Playwright "
+                "browsers are installed (run: playwright install chromium)."
+            ) from exc
+
+    def _convert_binary(self, content, content_type):
+        """
+        Convert non-HTML bytes to Markdown via MarkItDown using a temp file.
+
+        Args:
+            content (bytes): The raw response body.
+            content_type (str): The response content-type (used to pick a
+                sensible temp-file suffix so MarkItDown selects a converter).
+
+        Returns:
+            str: The Markdown produced by MarkItDown (possibly empty).
+        """
+        base = content_type.split(";")[0].strip().lower()
+        suffix = mimetypes.guess_extension(base) or ""
+        with tempfile.NamedTemporaryFile(
+            mode="wb", delete=False, suffix=suffix
+        ) as tmp:
+            tmp.write(content or b"")
+            tmp_path = tmp.name
+        try:
+            return str(MarkItDown().convert(tmp_path))
+        finally:
+            os.remove(tmp_path)
+
+    def _store_and_discover(self, html, url, depth, urls_list, pbar):
+        """
+        Scrape an HTML page, persist it, and enqueue newly discovered links.
+
+        Args:
+            html (str): The page HTML.
+            url (str): The page URL.
+            depth (int): The crawl depth of this page.
+            urls_list (list | None): The predefined URL list, if any. When set,
+                no new links are discovered.
+            pbar (tqdm.tqdm): Progress bar whose total grows with new links.
+        """
+        content, metadata = self.scrape_page(html, url)
+        self.db_manager.insert_page(url, content, json.dumps(metadata))
+
+        discover = self.max_depth < 0 or depth < self.max_depth
+        if urls_list or not discover:
+            return
+        new_links = self.fetch_links(html=html, url=url)
+        real_new_links_count = 0
+        for new_url in new_links:
+            canonical = utils.canonicalize_url(new_url)
+            if self.db_manager.insert_link(canonical, depth=depth + 1):
+                real_new_links_count += 1
+                logger.debug("Inserted new link %s into the database", canonical)
+        if real_new_links_count:
+            pbar.total += real_new_links_count
+            pbar.refresh()
+
+    def _store_binary(self, url, content, content_type):
+        """
+        Convert and persist a non-HTML document; no link discovery is performed.
+
+        Args:
+            url (str): The document URL.
+            content (bytes): The raw response body.
+            content_type (str): The response content-type.
+        """
+        markdown = self._convert_binary(content, content_type)
+        metadata = {"title": url, "content_type": content_type}
+        self.db_manager.insert_page(url, markdown, json.dumps(metadata))
+
+    def _process_response(self, url, response, depth, urls_list, pbar):
+        """
+        Persist a fetched response, dispatching by content type.
+
+        HTML responses are scraped and may discover new links. Responses whose
+        content type is listed in ``allow_types`` are ingested as non-HTML
+        documents (no discovery). The link is always marked visited.
+
+        Args:
+            url (str): The fetched URL.
+            response: A response-like object exposing ``status_code``,
+                ``headers``, ``text`` and ``content`` (``requests``/``httpx``
+                response or :class:`_RenderedResponse`), or ``None``.
+            depth (int): The crawl depth of this URL.
+            urls_list (list | None): The predefined URL list, if any.
+            pbar (tqdm.tqdm): Progress bar to update on link discovery.
+
+        Returns:
+            bool: ``True`` if a page/document was stored (counts toward the
+            ``max_pages`` bound), ``False`` if the response was skipped.
+        """
+        if response is None or response.status_code != 200:
+            self.db_manager.mark_link_visited(url)
+            logger.info("Skipping link %s due to invalid status code", url)
+            return False
+
+        content_type = response.headers.get("content-type", "")
+        if content_type.startswith("text/html"):
+            self._store_and_discover(response.text, url, depth, urls_list, pbar)
+            self.db_manager.mark_link_visited(url)
+            return True
+
+        base = content_type.split(";")[0].strip().lower()
+        if base in self.allow_types:
+            self._store_binary(url, response.content, content_type)
+            self.db_manager.mark_link_visited(url)
+            return True
+
+        self.db_manager.mark_link_visited(url)
+        logger.info(
+            "Skipping link %s due to unsupported content type %s", url, content_type
+        )
+        return False
+
     def fetch_links(self, url, html=None):
         """
         Fetch all valid links from the given URL.
@@ -342,6 +946,11 @@ class Scraper:
             tuple: A tuple containing the extracted content and metadata of the page.
         """
         logger.info(f"Scraping page {url}")
+
+        # Readability extraction bypasses the include/exclude + MarkItDown
+        # pipeline and lets trafilatura isolate the main content directly.
+        if self.extract == "readability":
+            return self._scrape_readability(html, url)
 
         try:
             # Parse the content using BeautifulSoup
@@ -427,6 +1036,10 @@ class Scraper:
             # Insert a single canonicalized URL if provided
             self.db_manager.insert_link(utils.canonicalize_url(url), depth=0)
 
+        # Optionally seed additional URLs from the host's sitemap.
+        if self.sitemap:
+            self._seed_from_sitemap()
+
         # Log the start of the scraping process
         logger.info("Starting scraping process")
 
@@ -500,70 +1113,33 @@ class Scraper:
                 url = link[0]  # Extract the URL from the link tuple
                 depth = link[1] if len(link) > 1 else 0  # Crawl depth of the link
 
-                # Attempt to fetch the page content with retry/backoff. Network
-                # failures that survive all retries must not crash the crawl
-                # loop: log, mark visited, and move on to the next link.
-                try:
-                    response = self._get_with_retry(url)
-                except requests.RequestException as exc:
-                    logger.warning("Failed to fetch %s: %s", url, exc)
+                # Honor robots.txt unless explicitly disabled.
+                if not self.ignore_robots and not self._robots_allowed(url):
+                    logger.info("Skipping %s (disallowed by robots.txt)", url)
                     self.db_manager.mark_link_visited(url)
                     continue
+
+                # Obtain the page. JS rendering substitutes a plain GET with a
+                # rendered-HTML response; otherwise fetch with retry/backoff.
+                # Network failures that survive all retries must not crash the
+                # crawl loop: log, mark visited, and move on to the next link.
+                if self.render:
+                    response = _RenderedResponse(self._render_sync(url))
+                else:
+                    try:
+                        response = self._get_with_retry(url)
+                    except requests.RequestException as exc:
+                        logger.warning("Failed to fetch %s: %s", url, exc)
+                        self.db_manager.mark_link_visited(url)
+                        continue
 
                 # Increment request count for rate limiting
                 request_count += 1
 
-                # Check for a successful response and correct content type. A
-                # retryable status that survived all retries lands here and is
-                # only now marked visited (not before retries were exhausted).
-                if (
-                    response is None
-                    or response.status_code != 200
-                    or not response.headers.get("content-type", "").startswith(
-                        "text/html"
-                    )
-                ):
-                    # Mark the link as visited and log the reason for skipping
-                    self.db_manager.mark_link_visited(url)
-                    logger.info(
-                        "Skipping link %s due to invalid status code or content type",
-                        url,
-                    )
-                    continue
-
-                # Extract the HTML content from the response
-                html = response.text
-
-                # Scrape the page for content and metadata
-                content, metadata = self.scrape_page(html, url)
-
-                # Insert the scraped data into the database
-                self.db_manager.insert_page(url, content, json.dumps(metadata))
-                scraped_count += 1
-
-                # Fetch and insert new links found on the page, if not working
-                # from a predefined list and still within the depth bound.
-                discover = self.max_depth < 0 or depth < self.max_depth
-                if not urls_list and discover:
-                    new_links = self.fetch_links(html=html, url=url)
-
-                    # Count and insert new links into the database at depth+1.
-                    real_new_links_count = 0
-                    for new_url in new_links:
-                        canonical = utils.canonicalize_url(new_url)
-                        if self.db_manager.insert_link(canonical, depth=depth + 1):
-                            real_new_links_count += 1
-                            logger.debug(
-                                f"Inserted new link {canonical} into the database"
-                            )
-
-                    # Update the progress bar total with the count of new links
-                    if real_new_links_count:
-                        pbar.total += real_new_links_count
-                        pbar.refresh()
-
-                # Mark the current link as visited in the database
-                self.db_manager.mark_link_visited(url)
+                # Persist the response (HTML or an allowed non-HTML document),
+                # marking the link visited and counting stored pages.
+                if self._process_response(url, response, depth, urls_list, pbar):
+                    scraped_count += 1
 
             # Break the outer loop too when a crawl bound has been reached.
             if stop:
@@ -587,6 +1163,9 @@ class Scraper:
             timeout=self.timeout,
             follow_redirects=True,
             proxy=self.proxy,
+            headers=self._headers or None,
+            cookies=self._cookies or None,
+            auth=self._auth,
         )
 
     async def _aget_with_retry(self, client, url):
@@ -678,6 +1257,11 @@ class Scraper:
         async with semaphore:
             if self.delay > 0:
                 await asyncio.sleep(self.delay)
+            if self.render:
+                try:
+                    return (url, _RenderedResponse(await self._render_async(url)), None)
+                except RuntimeError as exc:
+                    return (url, None, exc)
             try:
                 response = await self._aget_with_retry(client, url)
                 return (url, response, None)
@@ -714,6 +1298,10 @@ class Scraper:
             self.db_manager.insert_link(validated_urls, depth=0)
         elif url:
             self.db_manager.insert_link(utils.canonicalize_url(url), depth=0)
+
+        # Optionally seed additional URLs from the host's sitemap.
+        if self.sitemap:
+            self._seed_from_sitemap()
 
         logger.info(
             "Starting async scraping process (concurrency=%d)", self.concurrency
@@ -774,11 +1362,29 @@ class Scraper:
                         link[0]: (link[1] if len(link) > 1 else 0) for link in batch
                     }
 
+                    # Honor robots.txt before fetching: drop disallowed URLs
+                    # from the batch (robots is fetched at most once per host).
+                    allowed_batch = []
+                    for link in batch:
+                        candidate = link[0]
+                        if not self.ignore_robots and not await self._arobots_allowed(
+                            client, candidate
+                        ):
+                            logger.info(
+                                "Skipping %s (disallowed by robots.txt)", candidate
+                            )
+                            self.db_manager.mark_link_visited(candidate)
+                            pbar.update(1)
+                        else:
+                            allowed_batch.append(link)
+                    if not allowed_batch:
+                        continue
+
                     # Fetch the batch concurrently (DB untouched here).
                     results = await asyncio.gather(
                         *(
                             self._afetch_one(client, link[0], semaphore)
-                            for link in batch
+                            for link in allowed_batch
                         )
                     )
                     request_count += len(results)
@@ -797,7 +1403,7 @@ class Scraper:
                             stop = True
                             break
 
-                        # Persistent transport error: mark visited and move on.
+                        # Persistent transport/render error: mark visited, skip.
                         if error is not None:
                             logger.warning(
                                 "Failed to fetch %s: %s", fetched_url, error
@@ -805,48 +1411,11 @@ class Scraper:
                             self.db_manager.mark_link_visited(fetched_url)
                             continue
 
-                        # Skip non-200 / non-HTML responses (retries exhausted).
-                        if (
-                            response is None
-                            or response.status_code != 200
-                            or not response.headers.get(
-                                "content-type", ""
-                            ).startswith("text/html")
+                        # Persist the response (HTML or an allowed non-HTML
+                        # document); marks visited and discovers links for HTML.
+                        if self._process_response(
+                            fetched_url, response, depth, urls_list, pbar
                         ):
-                            self.db_manager.mark_link_visited(fetched_url)
-                            logger.info(
-                                "Skipping link %s due to invalid status code or "
-                                "content type",
-                                fetched_url,
-                            )
-                            continue
-
-                        html = response.text
-                        content, metadata = self.scrape_page(html, fetched_url)
-                        self.db_manager.insert_page(
-                            fetched_url, content, json.dumps(metadata)
-                        )
-                        scraped_count += 1
-
-                        # Discover new links while within the depth bound.
-                        discover = self.max_depth < 0 or depth < self.max_depth
-                        if not urls_list and discover:
-                            new_links = self.fetch_links(html=html, url=fetched_url)
-                            real_new_links_count = 0
-                            for new_url in new_links:
-                                canonical = utils.canonicalize_url(new_url)
-                                if self.db_manager.insert_link(
-                                    canonical, depth=depth + 1
-                                ):
-                                    real_new_links_count += 1
-                                    logger.debug(
-                                        "Inserted new link %s into the database",
-                                        canonical,
-                                    )
-                            if real_new_links_count:
-                                pbar.total += real_new_links_count
-                                pbar.refresh()
-
-                        self.db_manager.mark_link_visited(fetched_url)
+                            scraped_count += 1
         finally:
             pbar.close()

--- a/crawler_to_md/utils.py
+++ b/crawler_to_md/utils.py
@@ -1,7 +1,95 @@
 import logging
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 logger = logging.getLogger(__name__)
+
+# Query parameters considered tracking noise and dropped during canonicalization.
+# ``utm_*`` parameters are handled separately via a prefix check.
+_TRACKING_PARAMS = frozenset(
+    {
+        "fbclid",
+        "gclid",
+        "gclsrc",
+        "dclid",
+        "msclkid",
+        "mc_eid",
+        "mc_cid",
+        "_hsenc",
+        "_hsmi",
+    }
+)
+
+# Default ports that are redundant for their scheme and therefore stripped.
+_DEFAULT_PORTS = {"http": "80", "https": "443"}
+
+
+def _is_tracking_param(key):
+    """
+    Determine whether a query-parameter key is a tracking parameter.
+
+    Args:
+        key (str): The query-parameter name.
+
+    Returns:
+        bool: ``True`` if the key is a known tracking parameter (``utm_*`` or a
+        member of :data:`_TRACKING_PARAMS`), ``False`` otherwise.
+    """
+    lowered = key.lower()
+    return lowered.startswith("utm_") or lowered in _TRACKING_PARAMS
+
+
+def canonicalize_url(url):
+    """
+    Return a canonical form of ``url`` suitable for deduplicating equivalent URLs.
+
+    The following normalizations are applied without altering the semantic
+    target of the URL:
+
+    - lowercase the scheme and host (path and query values keep their case);
+    - strip the default port for the scheme (``80`` for HTTP, ``443`` for HTTPS);
+    - drop tracking query parameters (``utm_*``, ``fbclid``, ``gclid``, ...);
+    - sort the remaining query parameters for a stable ordering;
+    - remove the fragment;
+    - normalize an empty path to ``"/"``.
+
+    Args:
+        url (str): The URL to canonicalize.
+
+    Returns:
+        str: The canonicalized URL. Non-string input is returned unchanged.
+    """
+    if not isinstance(url, str):
+        return url
+
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+
+    # Split userinfo and host:port so only the host is lowercased.
+    netloc = parsed.netloc
+    userinfo = ""
+    hostport = netloc
+    if "@" in netloc:
+        userinfo, hostport = netloc.rsplit("@", 1)
+        userinfo += "@"
+    if ":" in hostport:
+        host, _, port = hostport.partition(":")
+    else:
+        host, port = hostport, ""
+    host = host.lower()
+    if port and _DEFAULT_PORTS.get(scheme) == port:
+        port = ""
+    netloc = f"{userinfo}{host}:{port}" if port else f"{userinfo}{host}"
+
+    # Normalize an empty path so "http://host" and "http://host/" collapse.
+    path = parsed.path or "/"
+
+    # Drop tracking parameters and sort the remainder for stability.
+    pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    filtered = [(k, v) for k, v in pairs if not _is_tracking_param(k)]
+    filtered.sort()
+    query = urlencode(filtered)
+
+    return urlunparse((scheme, netloc, path, parsed.params, query, ""))
 
 
 def randomstring_to_filename(random_string):

--- a/crawler_to_md/utils.py
+++ b/crawler_to_md/utils.py
@@ -1,9 +1,7 @@
+import logging
 from urllib.parse import urlparse, urlunparse
 
-from . import log_setup
-
-logger = log_setup.get_logger()
-logger.name = "utils"
+logger = logging.getLogger(__name__)
 
 
 def randomstring_to_filename(random_string):

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# crawler-to-md documentation
+
+| Guide | Description |
+|---|---|
+| [configuration.md](configuration.md) | `crawler-to-md.toml` reference: every key, precedence rules, auto-discovery, and the `LOG_LEVEL` env var |
+| [library.md](library.md) | Library API: `crawl()`, `CrawlConfig`, `CrawlResult`, `CrawlStats`, `run_crawl`, `run_export`, and worked examples |
+| [mcp.md](mcp.md) | MCP server guide: installation, launch, tool signatures, and client wiring |
+| [plugins.md](plugins.md) | Plugin system: protocols, first-party implementations, registry API, and registering third-party plugins |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,189 @@
+# Configuration reference
+
+crawler-to-md can be configured through a TOML file, through CLI flags, or
+through environment variables. The three sources are layered in this priority
+order (highest wins):
+
+```
+CLI flags  >  crawler-to-md.toml  >  built-in defaults
+```
+
+---
+
+## Config file auto-discovery
+
+When no `--config` flag is passed, the tool looks for `crawler-to-md.toml` in
+the current working directory. If the file exists it is loaded automatically.
+To use a file at a different path, pass `--config path/to/file.toml` explicitly.
+
+Keys in the TOML file may use either hyphens (`max-pages`) or underscores
+(`max_pages`); both map to the same option.
+
+---
+
+## LOG_LEVEL environment variable
+
+Logging verbosity is controlled by the `LOG_LEVEL` environment variable.
+The default level is `WARN`. Accepted values are the standard Python level
+names: `DEBUG`, `INFO`, `WARNING` / `WARN`, `ERROR`, `CRITICAL`.
+
+```shell
+LOG_LEVEL=INFO crawler-to-md --url https://example.com
+```
+
+---
+
+## Complete annotated example
+
+Copy this file to `crawler-to-md.toml` in your working directory, then
+uncomment and adjust the keys you need. CLI flags override every value shown
+here.
+
+```toml
+# crawler-to-md.toml
+# All keys are optional. Uncomment to override the default.
+
+# ── Input ────────────────────────────────────────────────────────────────────
+# url = "https://docs.example.com"        # single seed URL
+# urls-file = "urls.txt"                  # file of seed URLs (one per line); "-" = stdin
+
+# ── Output ───────────────────────────────────────────────────────────────────
+# output-folder = "./output"              # directory for exported artefacts
+# cache-folder  = "~/.cache/crawler-to-md"  # directory for SQLite databases
+
+# ── Identity ─────────────────────────────────────────────────────────────────
+# base-url = "https://docs.example.com"  # restrict crawl to URLs starting here
+                                          # (derived from seed URL when omitted)
+# title = "My Site Docs"                  # title for compiled exports
+                                          # (defaults to the seed URL)
+
+# ── Crawl control ────────────────────────────────────────────────────────────
+# overwrite-cache = false                 # remove existing cache DB before crawling
+# exclude-url = ["/tag/", "/author/"]     # skip URLs containing any of these strings
+# include-url = ["/docs/"]               # keep only URLs containing one of these strings
+# rate-limit  = 0                         # max requests/minute (0 = no limit)
+# delay       = 0                         # seconds between requests
+# proxy       = "http://proxy:8080"       # HTTP or SOCKS proxy URL
+
+# ── HTML filtering (applied before Markdown conversion) ──────────────────────
+# include = ["main", ".content", "#article"]  # CSS-like selectors to keep
+# exclude = ["nav", ".sidebar", "footer"]     # CSS-like selectors to remove
+
+# ── Robustness ───────────────────────────────────────────────────────────────
+# timeout     = 15                        # per-request timeout in seconds
+# max-retries = 3                         # retries on transient failures (timeout/429/5xx)
+# max-pages   = 0                         # stop after N pages (0 = unlimited)
+# max-depth   = -1                        # max link-discovery depth (-1 = unlimited)
+# max-time    = 0                         # max wall-clock crawl time in seconds (0 = unlimited)
+
+# ── Concurrency ──────────────────────────────────────────────────────────────
+# concurrency = 1                         # 1 = synchronous; N > 1 = async with bounded parallelism
+
+# ── Intelligence ─────────────────────────────────────────────────────────────
+# ignore-robots = false                   # bypass robots.txt (honoured by default)
+# user-agent    = "MyBot/1.0"             # custom User-Agent string
+# sitemap       = false                   # seed frontier from /sitemap.xml
+# extract       = "none"                  # "none" or "readability" (needs [readability] extra)
+# render        = false                   # JS rendering via Playwright (needs [render] extra)
+# header        = ["X-API-Key: secret"]   # extra request headers (list, repeatable on CLI)
+# cookie        = ["session=abc123"]      # cookies as "key=value" strings
+# auth          = "user:pass"             # HTTP Basic-auth credentials
+# allow-types   = ["application/pdf"]     # extra MIME types to ingest via MarkItDown
+
+# ── Output formats ───────────────────────────────────────────────────────────
+# export-individual = false               # one Markdown file per page
+# frontmatter       = true                # YAML frontmatter on individual files
+# no-markdown       = false               # disable the compiled .md output
+# no-json           = false               # disable the compiled .json output
+# export-jsonl      = false               # JSON Lines export (one record per line)
+# export-llms       = false               # llms.txt + llms-full.txt (llmstxt.org convention)
+# chunk-size        = 0                   # RAG chunk size in tokens (0 = disabled); needs [rag]
+# chunk-overlap     = 0                   # token overlap between consecutive chunks
+# export-vectors    = false               # Parquet export for vector indexing; needs [vector]
+```
+
+---
+
+## Key reference
+
+### Input / output
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `url` | string | — | Single seed URL |
+| `urls-file` | string | — | Path to a file of seed URLs (one per line); `"-"` reads stdin |
+| `output-folder` | string | `"./output"` | Root directory for exported artefacts |
+| `cache-folder` | string | `"~/.cache/crawler-to-md"` | Directory for SQLite cache databases |
+| `base-url` | string | derived from seed URL | Restrict crawl to URLs with this prefix |
+| `title` | string | seed URL | Title for compiled Markdown/JSON outputs |
+
+### Crawl control
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `overwrite-cache` | bool | `false` | Remove existing cache database before crawling |
+| `exclude-url` | list[string] | `[]` | Skip URLs containing any listed substring |
+| `include-url` | list[string] | `[]` | Keep only URLs containing at least one listed substring |
+| `rate-limit` | int | `0` | Max requests per minute (`0` = no limit) |
+| `delay` | float | `0` | Seconds to wait between requests |
+| `proxy` | string | — | HTTP or SOCKS proxy URL |
+
+### HTML filtering
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `include` | list[string] | `[]` | CSS-like selectors (`#id`, `.class`, `tag`) to keep before conversion |
+| `exclude` | list[string] | `[]` | CSS-like selectors to remove before conversion |
+
+### Robustness
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `timeout` | float | `15` | Per-request timeout in seconds |
+| `max-retries` | int | `3` | Retries on timeout, 429, or 5xx responses |
+| `max-pages` | int | `0` | Stop after N pages scraped (`0` = unlimited) |
+| `max-depth` | int | `-1` | Max link-discovery depth (`-1` = unlimited) |
+| `max-time` | float | `0` | Max wall-clock crawl time in seconds (`0` = unlimited) |
+
+### Concurrency
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `concurrency` | int | `1` | Number of concurrent fetches (`1` = synchronous path) |
+
+### Intelligence
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `ignore-robots` | bool | `false` | Bypass `robots.txt` (honoured by default) |
+| `user-agent` | string | — | Custom User-Agent string on every request |
+| `sitemap` | bool | `false` | Seed the frontier from the host's `/sitemap.xml` |
+| `extract` | string | `"none"` | Content extraction strategy: `"none"` or `"readability"` (needs `[readability]` extra) |
+| `render` | bool | `false` | Fetch JS-rendered HTML via Playwright (needs `[render]` extra + `playwright install chromium`) |
+| `header` | list[string] | `[]` | Extra request headers as `"Key: Value"` strings |
+| `cookie` | list[string] | `[]` | Request cookies as `"key=value"` strings |
+| `auth` | string | — | HTTP Basic-auth credentials as `"user:pass"` |
+| `allow-types` | list[string] | `[]` | Extra MIME types to ingest via MarkItDown (e.g. `"application/pdf"`) |
+
+### Output formats
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `export-individual` | bool | `false` | Export each page as an individual Markdown file |
+| `frontmatter` | bool | `true` | Prepend YAML frontmatter to individual Markdown exports |
+| `no-markdown` | bool | `false` | Disable the compiled `.md` file |
+| `no-json` | bool | `false` | Disable the compiled `.json` file |
+| `export-jsonl` | bool | `false` | Export as JSON Lines (one `{url, content, metadata}` per line) |
+| `export-llms` | bool | `false` | Export `llms.txt` (index) + `llms-full.txt` (full content) |
+| `chunk-size` | int | `0` | RAG chunk size in tokens (`0` = disabled); requires `[rag]` extra |
+| `chunk-overlap` | int | `0` | Token overlap between consecutive RAG chunks |
+| `export-vectors` | bool | `false` | Export to a Parquet file for vector indexing; requires `[vector]` extra |
+
+---
+
+## Notes
+
+- The `export` subcommand accepts the same output-format keys but not the
+  crawl-control keys (it reads from an existing cache database).
+- The `mcp` subcommand ignores the config file entirely.
+- When `urls-file` is set, the `url` key is ignored.

--- a/docs/library.md
+++ b/docs/library.md
@@ -1,0 +1,284 @@
+# Library API
+
+`crawler-to-md` is importable as a library. It has no CLI side effects: it
+performs no argument parsing, does not print to stdout, and never calls
+`sys.exit`. Errors propagate as standard Python exceptions.
+
+---
+
+## Import surface
+
+```python
+from crawler_to_md import (
+    crawl,           # high-level entry point
+    CrawlConfig,     # declarative configuration dataclass
+    CrawlResult,     # returned by crawl() / run_crawl() / run_export()
+    CrawlStats,      # aggregate run statistics (nested in CrawlResult)
+    run_crawl,       # lower-level orchestration: build config → crawl → export
+    run_export,      # re-run exports from an existing cache, no crawl
+    Scraper,         # HTTP fetch + link-discovery engine
+    ExportManager,   # corpus export (Markdown, JSON, JSONL, llms.txt, …)
+    DatabaseManager, # SQLite wrapper (crawl frontier + page store)
+)
+```
+
+All names above are in `__all__` and are stable public API.
+
+---
+
+## `crawl()`
+
+```python
+def crawl(
+    url: str | None = None,
+    *,
+    urls: Iterable[str] | None = None,
+    **options,
+) -> CrawlResult:
+```
+
+The simplest entry point. Pass a single URL or an iterable of seed URLs, plus
+any `CrawlConfig` field as a keyword argument.
+
+**Library defaults differ from the CLI defaults:**
+
+- `no_markdown=True` — no compiled `.md` file is written unless you opt in.
+- `no_json=True` — no compiled `.json` file is written unless you opt in.
+- `cache_folder` — an isolated temporary directory is used unless you supply
+  one; the directory is not cleaned up automatically (use `tempfile.TemporaryDirectory`
+  if you need that).
+
+**Raises:**
+
+- `TypeError` — an unknown keyword argument was passed.
+- `ValueError` — neither `url` nor `urls` was supplied, or scraper construction
+  failed (e.g. an unreachable proxy).
+
+---
+
+## Keyword options (`**options`)
+
+Any field of `CrawlConfig` may be passed as a keyword argument to `crawl()`.
+The table below lists the most useful ones with their types and defaults.
+
+### Input
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `url` | `str \| None` | `None` | Single seed URL (positional-or-keyword) |
+| `urls` | `Iterable[str] \| None` | `None` | Iterable of seed URLs |
+| `base_url` | `str \| None` | derived | Restrict crawl to URLs starting with this prefix |
+
+### Output
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `output_folder` | `str` | `"./output"` | Root directory for exported artefacts |
+| `cache_folder` | `str` | temp dir | SQLite cache directory |
+| `overwrite_cache` | `bool` | `False` | Remove existing cache before crawling |
+| `title` | `str \| None` | seed URL | Title for compiled exports |
+| `no_markdown` | `bool` | `True`* | Disable compiled `.md` output |
+| `no_json` | `bool` | `True`* | Disable compiled `.json` output |
+| `export_individual` | `bool` | `False` | One Markdown file per page |
+| `frontmatter` | `bool` | `True` | YAML frontmatter on individual files |
+| `export_jsonl` | `bool` | `False` | JSON Lines export |
+| `export_llms` | `bool` | `False` | `llms.txt` + `llms-full.txt` export |
+| `chunk_size` | `int` | `0` | RAG chunk size in tokens (`0` = off); needs `[rag]` |
+| `chunk_overlap` | `int` | `0` | Token overlap between chunks |
+| `export_vectors` | `bool` | `False` | Parquet export; needs `[vector]` |
+
+*Library-only default (CLI default is `False`).
+
+### Crawl control
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `exclude_url` | `list[str]` | `[]` | Skip URLs containing any of these substrings |
+| `include_url` | `list[str]` | `[]` | Keep only URLs containing one of these substrings |
+| `max_pages` | `int` | `0` | Stop after N pages (`0` = unlimited) |
+| `max_depth` | `int` | `-1` | Max link-discovery depth (`-1` = unlimited) |
+| `max_time` | `float` | `0` | Max wall-clock time in seconds (`0` = unlimited) |
+| `rate_limit` | `int` | `0` | Max requests/minute (`0` = no limit) |
+| `delay` | `float` | `0` | Seconds between requests |
+| `concurrency` | `int` | `1` | Concurrent fetches (`1` = sync, `N>1` = async) |
+| `proxy` | `str \| None` | `None` | HTTP or SOCKS proxy URL |
+
+### Network / auth
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `timeout` | `float` | `15` | Per-request timeout in seconds |
+| `max_retries` | `int` | `3` | Retries on timeout / 429 / 5xx |
+| `user_agent` | `str \| None` | `None` | Custom User-Agent string |
+| `header` | `list[str]` | `[]` | Extra headers as `"Key: Value"` strings |
+| `cookie` | `list[str]` | `[]` | Cookies as `"key=value"` strings |
+| `auth` | `str \| None` | `None` | HTTP Basic-auth as `"user:pass"` |
+
+### Content shaping
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `include` | `list[str]` | `[]` | CSS-like selectors to keep before conversion |
+| `exclude` | `list[str]` | `[]` | CSS-like selectors to remove before conversion |
+| `extract` | `str` | `"none"` | `"none"` or `"readability"` (needs `[readability]`) |
+| `render` | `bool` | `False` | JS rendering via Playwright (needs `[render]`) |
+| `sitemap` | `bool` | `False` | Seed frontier from `/sitemap.xml` |
+| `ignore_robots` | `bool` | `False` | Bypass `robots.txt` |
+| `allow_types` | `list[str]` | `[]` | Extra MIME types for MarkItDown ingestion |
+
+---
+
+## `CrawlResult`
+
+`crawl()`, `run_crawl()`, and `run_export()` all return a `CrawlResult`
+dataclass with three fields:
+
+```python
+@dataclass
+class CrawlResult:
+    pages:   list[dict]       # one dict per stored page
+    stats:   CrawlStats       # aggregate run statistics
+    exports: dict[str, Any]   # paths of artefacts actually written
+```
+
+### `pages`
+
+A list of dicts. Each dict has exactly these keys:
+
+```python
+{
+    "url":      str,   # the page URL
+    "content":  str,   # Markdown content of the page
+    "metadata": dict,  # decoded JSON metadata (title, fetched_at, …)
+}
+```
+
+### `stats` — `CrawlStats`
+
+```python
+@dataclass
+class CrawlStats:
+    links_discovered: int    # total URLs added to the frontier
+    pages_scraped:    int    # URLs marked as visited
+    pages_stored:     int    # pages with non-empty content in the DB
+    content_bytes:    int    # total UTF-8 byte size of stored content
+    total_tokens:     int    # total token count across the corpus
+    token_method:     str    # "tiktoken" (exact) or "word-estimate"
+    duration:         float  # wall-clock duration of the run in seconds
+```
+
+### `exports`
+
+A dict mapping export name to path(s) written. Only exports that were
+actually requested appear. Known keys:
+
+| Key | Value |
+|---|---|
+| `"markdown"` | path to the compiled `.md` file |
+| `"json"` | path to the compiled `.json` file |
+| `"individual"` | path to the `files/` folder containing per-page files |
+| `"jsonl"` | path to the `.jsonl` file |
+| `"llms"` | `tuple[str, str]` — paths to `llms.txt` and `llms-full.txt` |
+| `"chunks"` | path to the `chunks.jsonl` file |
+| `"vectors"` | path to the `.parquet` file |
+| `"errors"` | `dict[str, str]` — export name → error message for failed optional exports |
+
+---
+
+## `run_crawl()` and `run_export()`
+
+For cases where you need full control over the configuration, use these
+lower-level functions directly:
+
+```python
+from crawler_to_md import run_crawl, run_export, CrawlConfig
+
+config = CrawlConfig(
+    url="https://docs.example.com",
+    max_pages=100,
+    no_markdown=False,
+    no_json=True,
+    export_llms=True,
+)
+result = run_crawl(config)
+
+# Re-run exports without re-crawling:
+config.export_jsonl = True
+result2 = run_export(config)
+```
+
+`run_export()` raises `ValueError` if no cache database exists for the URL.
+
+---
+
+## Worked examples
+
+### Basic crawl — iterate over pages in memory
+
+```python
+from crawler_to_md import crawl
+
+result = crawl("https://docs.example.com", max_pages=50)
+
+for page in result.pages:
+    print(page["url"], len(page["content"]))
+
+print(
+    f"{result.stats.pages_stored} pages, "
+    f"{result.stats.total_tokens} tokens "
+    f"({result.stats.token_method}), "
+    f"{result.stats.duration:.1f}s"
+)
+```
+
+### Crawl and write JSONL + llms.txt
+
+```python
+from crawler_to_md import crawl
+
+result = crawl(
+    "https://docs.example.com",
+    max_pages=200,
+    no_markdown=True,
+    no_json=True,
+    export_jsonl=True,
+    export_llms=True,
+    output_folder="./exports",
+)
+
+print("JSONL written to:", result.exports["jsonl"])
+print("llms.txt at:     ", result.exports["llms"][0])
+print("llms-full.txt at:", result.exports["llms"][1])
+```
+
+### Async crawl with concurrency and RAG chunking
+
+```python
+from crawler_to_md import crawl
+
+result = crawl(
+    "https://docs.example.com",
+    concurrency=8,          # async httpx engine
+    max_pages=500,
+    max_time=120,           # cap at 2 minutes
+    chunk_size=512,
+    chunk_overlap=64,
+    output_folder="./rag-export",
+)
+
+print(f"Chunks written to: {result.exports['chunks']}")
+print(f"Errors (if any):   {result.exports.get('errors', {})}")
+```
+
+---
+
+## Notes
+
+- `crawl()` never calls `sys.exit` and never writes exports unless you
+  explicitly enable them (all export flags default to off in library mode,
+  with `no_markdown=True` and `no_json=True`).
+- The `cache_folder` temporary directory created by the library is not
+  cleaned up automatically. Wrap the call in a `tempfile.TemporaryDirectory`
+  context manager if you need guaranteed cleanup.
+- `CrawlResult.pages` is a `list[dict]` — access fields with `page["url"]`,
+  not `page.url`.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,141 @@
+# MCP server
+
+crawler-to-md ships an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/)
+server that exposes crawling as two tools an AI agent or orchestrator can call
+directly over stdio.
+
+---
+
+## Installation
+
+The MCP server requires the optional `mcp` extra, which pulls in the
+`mcp` Python SDK (`fastmcp`):
+
+```shell
+pip install "crawler-to-md[mcp]"
+```
+
+---
+
+## Launching the server
+
+```shell
+crawler-to-md mcp
+```
+
+The server runs over **stdio** (standard input / standard output) and blocks
+until the client disconnects. It does not bind any network port.
+
+---
+
+## Tools
+
+### `crawl`
+
+Crawl a site or page and return its pages and run statistics.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | `string` | yes | Base URL to crawl |
+| `options` | `object \| null` | no | Keyword overrides forwarded to `crawler_to_md.crawl()` (e.g. `max_pages`, `max_depth`, `concurrency`, `include_url`) |
+
+**Returns** `object`:
+
+```json
+{
+  "pages": [
+    {
+      "url": "https://example.com/page",
+      "content": "# Page title\n\nPage content…",
+      "metadata": { "title": "Page title", "fetched_at": "2024-01-01T00:00:00" }
+    }
+  ],
+  "stats": {
+    "links_discovered": 42,
+    "pages_scraped": 40,
+    "pages_stored": 38,
+    "content_bytes": 184320,
+    "total_tokens": 46080,
+    "token_method": "word-estimate",
+    "duration": 12.4
+  }
+}
+```
+
+### `fetch_as_markdown`
+
+Fetch a single URL and return its Markdown content. No link discovery is
+performed: the crawl is bounded to one page at depth zero.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | `string` | yes | URL to fetch and convert to Markdown |
+| `options` | `object \| null` | no | Keyword overrides forwarded to `crawler_to_md.crawl()` (e.g. `timeout`, `user_agent`, `render`) |
+
+**Returns** `string` — the Markdown content of the page.
+
+**Raises** (surfaced as an MCP error): `RuntimeError` if no content could be
+fetched from the URL.
+
+---
+
+## Wiring into an MCP client
+
+Point your MCP client at the `crawler-to-md mcp` command. The exact config
+format depends on the client; below is a typical Claude Desktop / agent config
+snippet:
+
+```json
+{
+  "mcpServers": {
+    "crawler-to-md": {
+      "command": "crawler-to-md",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+If `crawler-to-md` is not on `PATH` (e.g. installed in a virtual environment),
+use the absolute path to the executable:
+
+```json
+{
+  "mcpServers": {
+    "crawler-to-md": {
+      "command": "/path/to/venv/bin/crawler-to-md",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+With `uvx` (no permanent install needed):
+
+```json
+{
+  "mcpServers": {
+    "crawler-to-md": {
+      "command": "uvx",
+      "args": ["--extra", "mcp", "crawler-to-md", "mcp"]
+    }
+  }
+}
+```
+
+---
+
+## Implementation notes
+
+- The server is built with `mcp.server.fastmcp.FastMCP` under the name
+  `"crawler-to-md"`.
+- The underlying tool logic lives in plain callables (`crawl_tool` and
+  `fetch_as_markdown` in `crawler_to_md/mcp_server.py`) that can be imported
+  and tested independently without the MCP SDK installed.
+- If the `mcp` extra is missing and you run `crawler-to-md mcp`, the CLI
+  prints a clear error message (`pip install crawler-to-md[mcp]`) and exits
+  with code 1.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,106 @@
+# Plugin system
+
+`crawler-to-md` exposes an entry-point-based plugin architecture. The pipeline
+is described by four typed protocols (defined in `crawler_to_md/plugins.py`),
+and implementations are discovered through Python
+[entry points](https://packaging.python.org/en/latest/specifications/entry-points/).
+
+All first-party features ship as plugins, and third parties can add their own by
+declaring entry points in the same groups — no fork required.
+
+## Protocols
+
+Each protocol is a `typing.Protocol` with a `name` attribute (its registry key)
+and a single method.
+
+| Group | Entry-point group | Protocol | Method |
+| --- | --- | --- | --- |
+| Formatters | `crawler_to_md.formatters` | `Formatter` | `export(manager, output_path, **options)` |
+| Filters | `crawler_to_md.filters` | `Filter` | `is_allowed(url) -> bool` |
+| Processors | `crawler_to_md.processors` | `Processor` | `process(html, url) -> str` |
+| Fetchers | `crawler_to_md.fetchers` | `Fetcher` | `fetch(url)` |
+
+- **Formatter** — renders the crawled corpus to disk. Receives the live
+  `ExportManager` (database connection + run title) and a destination path.
+- **Filter** — decides whether a discovered URL belongs in the crawl frontier.
+- **Processor** — transforms a page's HTML before Markdown conversion.
+- **Fetcher** — retrieves a URL and returns a response-like object exposing
+  `status_code`, `headers`, `text` and `content`.
+
+## First-party implementations
+
+These are registered as entry points in `pyproject.toml` and are also built into
+the registry, so they are always available even before the distribution metadata
+is refreshed.
+
+- **Formatters**: `markdown`, `json`, `jsonl`, `llms`, `individual`, `chunks`,
+  `vectors` — each delegates to the corresponding `ExportManager.export_to_*`
+  method, so output is byte-identical to calling that method directly.
+- **Filters**: `url-pattern` — the canonical include/exclude URL filter
+  (mirrors `Scraper.is_valid_link`).
+- **Processors**: `noop` — pass-through (returns HTML unchanged).
+- **Fetchers**: `requests` — a `requests`-session GET; via
+  `RequestsFetcher.from_scraper(...)` it reuses the scraper's retry/backoff GET.
+
+## Using the registry
+
+```python
+from crawler_to_md.plugins import get_registry
+
+registry = get_registry()
+
+registry.names("formatters")          # -> ['chunks', 'individual', 'json', ...]
+registry.get("formatters", "markdown")  # -> the MarkdownFormatter class
+formatter = registry.create("formatters", "markdown")  # -> an instance
+```
+
+`ExportManager` re-expresses every export through the registry:
+
+```python
+manager.export_with("markdown", "out.md")
+manager.export_with("individual", "out/", base_url="https://example.com")
+manager.export_with("chunks", "chunks.jsonl", chunk_size=512, chunk_overlap=64)
+```
+
+Discovery is defensive: a missing distribution, an absent group, or an
+individual plugin that fails to import is logged and skipped — it never raises.
+Results are cached per group; call `registry.clear_cache()` (or
+`discover(group, refresh=True)`) to force a re-scan.
+
+## Registering a third-party plugin
+
+Declare an entry point in your own package's `pyproject.toml`, pointing at a
+class that implements the relevant protocol:
+
+```toml
+[project.entry-points."crawler_to_md.formatters"]
+my-format = "my_package.exporters:MyFormatter"
+
+[project.entry-points."crawler_to_md.filters"]
+my-filter = "my_package.filters:MyFilter"
+
+[project.entry-points."crawler_to_md.processors"]
+my-processor = "my_package.processors:MyProcessor"
+
+[project.entry-points."crawler_to_md.fetchers"]
+my-fetcher = "my_package.fetchers:MyFetcher"
+```
+
+A minimal formatter:
+
+```python
+class MyFormatter:
+    name = "my-format"
+
+    def export(self, manager, output_path, **options):
+        pages = manager.db_manager.get_all_pages()
+        with open(output_path, "w", encoding="utf-8") as handle:
+            for url, content, _metadata in pages:
+                handle.write(f"{url}\n")
+        return len(pages)
+```
+
+Once your package is installed, the plugin is discovered automatically and an
+entry-point name overrides a built-in of the same name. See
+`tests/sample_plugin.py` for a worked example exercised end-to-end in the test
+suite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,26 @@ vector = ["pyarrow"]
 [project.scripts]
 crawler-to-md = "crawler_to_md.cli:main"
 
+# First-party pipeline plugins, discovered via the plugin registry. Third
+# parties register additional plugins under the same groups.
+[project.entry-points."crawler_to_md.formatters"]
+markdown = "crawler_to_md.plugins:MarkdownFormatter"
+json = "crawler_to_md.plugins:JsonFormatter"
+jsonl = "crawler_to_md.plugins:JsonlFormatter"
+llms = "crawler_to_md.plugins:LlmsFormatter"
+individual = "crawler_to_md.plugins:IndividualMarkdownFormatter"
+chunks = "crawler_to_md.plugins:ChunksFormatter"
+vectors = "crawler_to_md.plugins:VectorsFormatter"
+
+[project.entry-points."crawler_to_md.filters"]
+url-pattern = "crawler_to_md.plugins:UrlPatternFilter"
+
+[project.entry-points."crawler_to_md.processors"]
+noop = "crawler_to_md.plugins:NoOpProcessor"
+
+[project.entry-points."crawler_to_md.fetchers"]
+requests = "crawler_to_md.plugins:RequestsFetcher"
+
 # URLs related to the project repository and issue tracker
 [project.urls]
 Homepage = "https://github.com/obeone/crawler-to-md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "coloredlogs==15.0.1",
     "beautifulsoup4==4.13.4",
     "argcomplete==3.6.2",
+    "tomli; python_version < '3.11'",
 ]
 
 [tool.setuptools_scm]
@@ -47,6 +48,7 @@ readability = ["trafilatura"]
 render = ["playwright"]
 rag = ["tiktoken"]
 vector = ["pyarrow"]
+mcp = ["mcp"]
 
 # Entry points for command-line interface scripts
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "mdformat_frontmatter==2.0.8",
     "mdformat_tables==1.0.0",
     "requests[socks]==2.32.4",
+    "httpx>=0.27",
     "tqdm==4.67.1",
     "markitdown==0.1.2",
     "coloredlogs==15.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ local_scheme   = "no-local-version"
 dev = ["pytest", "ruff", "pytest-cov"]
 readability = ["trafilatura"]
 render = ["playwright"]
+rag = ["tiktoken"]
+vector = ["pyarrow"]
 
 # Entry points for command-line interface scripts
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ local_scheme   = "no-local-version"
 # Optional dependencies for additional features or development
 [project.optional-dependencies]
 dev = ["pytest", "ruff", "pytest-cov"]
+readability = ["trafilatura"]
+render = ["playwright"]
 
 # Entry points for command-line interface scripts
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,8 @@ version_scheme = "post-release"
 local_scheme   = "no-local-version"
 
 # Optional dependencies for additional features or development
-# Uncomment and customize as needed
-# [project.optional-dependencies]
-# dev = ["pytest", "ruff"]
+[project.optional-dependencies]
+dev = ["pytest", "ruff", "pytest-cov"]
 
 # Entry points for command-line interface scripts
 [project.scripts]

--- a/tests/sample_plugin.py
+++ b/tests/sample_plugin.py
@@ -1,0 +1,45 @@
+"""
+In-repo example of a third-party-style plugin.
+
+This module is *not* part of the distributed package; it exists so the test
+suite can register a custom :class:`~crawler_to_md.plugins.Formatter` through a
+fake entry point and exercise it end-to-end, proving that external plugins work
+without modifying the core code.
+"""
+
+
+class SampleFormatter:
+    """
+    Minimal third-party-style formatter that writes a URL listing.
+
+    It reads the crawled pages straight from the export manager's database and
+    writes one ``"<url>"`` line per stored page, prefixed by a banner, to prove
+    a registry-discovered formatter has full access to the corpus.
+    """
+
+    name = "sample"
+
+    def export(self, manager, output_path, **options):
+        """
+        Write a banner plus one line per page URL to ``output_path``.
+
+        Parameters
+        ----------
+        manager : crawler_to_md.export_manager.ExportManager
+            The export manager owning the database connection.
+        output_path : str
+            Destination text file.
+        **options
+            Ignored; accepted for protocol compatibility.
+
+        Returns
+        -------
+        int
+            The number of page URLs written.
+        """
+        pages = manager.db_manager.get_all_pages()
+        lines = ["# sample-plugin export"]
+        lines.extend(url for url, _content, _metadata in pages)
+        with open(output_path, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+        return len(pages)

--- a/tests/test_ai_outputs.py
+++ b/tests/test_ai_outputs.py
@@ -1,0 +1,284 @@
+"""
+Tests for Wave 2b AI-ready output formats (§5).
+
+Covers JSONL export, YAML frontmatter on individual Markdown, llms.txt /
+llms-full.txt, RAG chunking (rag extra + missing-extra error), Parquet vector
+export (vector extra + missing-extra error), token accounting and the
+end-of-run summary printed by ``cli.main``.
+"""
+
+import builtins
+import json
+import sys
+
+import pytest
+
+from crawler_to_md import cli, rag
+from crawler_to_md.database_manager import DatabaseManager
+from crawler_to_md.export_manager import (
+    VECTOR_MISSING_MESSAGE,
+    ExportManager,
+)
+from crawler_to_md.scraper import Scraper
+
+
+def _populated_db():
+    """
+    Build an in-memory database with two non-empty pages and one empty one.
+
+    Returns:
+        DatabaseManager: A ready-to-export database manager.
+    """
+    db = DatabaseManager(":memory:")
+    db.insert_page(
+        "http://example.com/a",
+        "# Alpha\n\nThe quick brown fox jumps over the lazy dog.",
+        json.dumps({"title": "Alpha Page"}),
+    )
+    db.insert_page(
+        "http://example.com/b",
+        "# Bravo\n\nAnother paragraph with several words here.",
+        json.dumps({"title": "Bravo Page"}),
+    )
+    db.insert_page("http://example.com/empty", None, "{}")
+    return db
+
+
+# ---------------------------------------------------------------------------
+# 2.7 JSONL export
+# ---------------------------------------------------------------------------
+
+
+def test_export_jsonl_round_trips_records(tmp_path):
+    db = _populated_db()
+    exporter = ExportManager(db, title="Site")
+    out = tmp_path / "out.jsonl"
+
+    exporter.export_to_jsonl(str(out))
+
+    lines = out.read_text(encoding="utf-8").splitlines()
+    # Two non-empty pages; the None-content page is skipped.
+    assert len(lines) == 2
+    records = [json.loads(line) for line in lines]
+    urls = {r["url"] for r in records}
+    assert urls == {"http://example.com/a", "http://example.com/b"}
+    for record in records:
+        assert set(record.keys()) == {"url", "content", "metadata"}
+        assert record["content"]
+        assert "title" in record["metadata"]
+
+
+# ---------------------------------------------------------------------------
+# 2.8 YAML frontmatter on individual Markdown
+# ---------------------------------------------------------------------------
+
+
+def _parse_frontmatter(text):
+    """
+    Extract the YAML frontmatter key/value lines from a Markdown document.
+
+    Returns:
+        dict[str, str]: Mapping of frontmatter keys to their raw string values.
+    """
+    assert text.startswith("---\n")
+    end = text.index("\n---", 4)
+    block = text[4:end]
+    parsed = {}
+    for line in block.splitlines():
+        key, _, value = line.partition(":")
+        parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def test_individual_markdown_has_frontmatter(tmp_path):
+    db = _populated_db()
+    exporter = ExportManager(db, title="Site")
+
+    exporter.export_individual_markdown(str(tmp_path))
+
+    page = tmp_path / "files" / "example.com" / "a.md"
+    text = page.read_text(encoding="utf-8")
+    fm = _parse_frontmatter(text)
+    assert "url" in fm and "example.com/a" in fm["url"]
+    assert fm["title"] == '"Alpha Page"'
+    assert "fetched_at" in fm
+    assert int(fm["word_count"]) > 0
+    # Body content is preserved after the frontmatter block.
+    assert "# Alpha" in text
+
+
+def test_individual_markdown_frontmatter_can_be_disabled(tmp_path):
+    db = _populated_db()
+    exporter = ExportManager(db, title="Site")
+
+    exporter.export_individual_markdown(str(tmp_path), frontmatter=False)
+
+    page = tmp_path / "files" / "example.com" / "a.md"
+    text = page.read_text(encoding="utf-8")
+    assert not text.startswith("---")
+    assert text.startswith("# Alpha")
+
+
+# ---------------------------------------------------------------------------
+# 2.9 llms.txt / llms-full.txt
+# ---------------------------------------------------------------------------
+
+
+def test_export_llms_produces_index_and_full(tmp_path):
+    db = _populated_db()
+    exporter = ExportManager(db, title="My Site")
+
+    index_path, full_path = exporter.export_to_llms(str(tmp_path))
+
+    index = open(index_path, encoding="utf-8").read()
+    full = open(full_path, encoding="utf-8").read()
+
+    assert index.startswith("# My Site")
+    assert "## Pages" in index
+    assert "[Alpha Page](http://example.com/a)" in index
+    assert "[Bravo Page](http://example.com/b)" in index
+
+    assert full.startswith("# My Site")
+    assert "quick brown fox" in full
+    assert "Another paragraph" in full
+
+
+# ---------------------------------------------------------------------------
+# 2.10 RAG chunking (rag extra) + missing-extra error
+# ---------------------------------------------------------------------------
+
+
+def test_chunks_jsonl_with_tiktoken(tmp_path):
+    pytest.importorskip("tiktoken")
+    db = _populated_db()
+    exporter = ExportManager(db, title="Site")
+    out = tmp_path / "chunks.jsonl"
+
+    total = exporter.export_chunks_jsonl(str(out), chunk_size=8, chunk_overlap=2)
+
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert total == len(lines) >= 2
+    for line in lines:
+        record = json.loads(line)
+        assert set(record.keys()) == {
+            "url",
+            "chunk_index",
+            "content",
+            "token_count",
+        }
+        assert record["token_count"] > 0
+
+
+def test_chunks_jsonl_missing_extra_raises(tmp_path, monkeypatch):
+    def _raise():
+        raise ImportError(rag.RAG_MISSING_MESSAGE)
+
+    monkeypatch.setattr(rag, "_load_tiktoken", _raise)
+
+    db = _populated_db()
+    exporter = ExportManager(db, title="Site")
+    with pytest.raises(ImportError, match="rag"):
+        exporter.export_chunks_jsonl(
+            str(tmp_path / "chunks.jsonl"), chunk_size=8
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2.12 Vector / Parquet export (vector extra) + missing-extra error
+# ---------------------------------------------------------------------------
+
+
+def test_export_vectors_with_pyarrow(tmp_path):
+    pytest.importorskip("pyarrow")
+    import pyarrow.parquet as pq
+
+    db = _populated_db()
+    exporter = ExportManager(db, title="Site")
+    out = tmp_path / "vectors.parquet"
+
+    rows = exporter.export_to_vectors(str(out))
+
+    assert rows == 2
+    table = pq.read_table(str(out))
+    assert set(table.column_names) == {
+        "url",
+        "content",
+        "metadata",
+        "token_count",
+    }
+    assert table.num_rows == 2
+
+
+def test_export_vectors_missing_extra_raises(tmp_path, monkeypatch):
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name.startswith("pyarrow"):
+            raise ImportError("No module named 'pyarrow'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    db = _populated_db()
+    exporter = ExportManager(db, title="Site")
+    with pytest.raises(ImportError, match="vector"):
+        exporter.export_to_vectors(str(tmp_path / "vectors.parquet"))
+
+    assert "vector" in VECTOR_MISSING_MESSAGE
+
+
+# ---------------------------------------------------------------------------
+# 2.11 Token accounting
+# ---------------------------------------------------------------------------
+
+
+def test_compute_token_totals_word_estimate(monkeypatch):
+    # Force the tiktoken-free path so the labelled estimate is exercised.
+    def _raise():
+        raise ImportError(rag.RAG_MISSING_MESSAGE)
+
+    monkeypatch.setattr(rag, "_load_tiktoken", _raise)
+
+    db = _populated_db()
+    exporter = ExportManager(db, title="Site")
+    total, method, page_count = exporter.compute_token_totals()
+
+    assert method == "word-estimate"
+    assert total > 0
+    assert page_count == 2
+
+
+def test_estimate_tokens_labels_method():
+    count, method = rag.estimate_tokens("one two three four")
+    assert count > 0
+    assert method in {"tiktoken", "word-estimate"}
+
+
+# ---------------------------------------------------------------------------
+# 2.13 Run summary printed by cli.main
+# ---------------------------------------------------------------------------
+
+
+def test_cli_prints_run_summary(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
+
+    cache_folder = tmp_path / "cache"
+    args = [
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
+        str(tmp_path),
+        "--cache-folder",
+        str(cache_folder),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    cli.main()
+
+    out = capsys.readouterr().out
+    assert "Run summary" in out
+    assert "Pages scraped" in out
+    assert "Total tokens" in out
+    assert "Duration" in out

--- a/tests/test_async_scraper.py
+++ b/tests/test_async_scraper.py
@@ -1,0 +1,211 @@
+"""Tests for the asynchronous crawl path and its parity with the sync path."""
+
+import asyncio
+
+import httpx
+
+from crawler_to_md.database_manager import DatabaseManager
+from crawler_to_md.scraper import Scraper
+
+
+class _DummyDB:
+    """Minimal DatabaseManager stand-in for unit tests that don't touch the DB."""
+
+    def __del__(self):
+        pass
+
+
+class FixtureTransport(httpx.AsyncBaseTransport):
+    """
+    An httpx async transport that serves a fixed map of URL -> HTML.
+
+    Optionally records in-flight concurrency (to prove overlapping requests)
+    and sleeps to widen the overlap window.
+    """
+
+    def __init__(self, pages, tracker=None, delay=0.0):
+        """
+        Args:
+            pages (dict[str, str]): Mapping of absolute URL to HTML body.
+            tracker (dict | None): Optional dict with ``inflight``/``max`` keys
+                updated to record concurrency.
+            delay (float): Seconds to sleep inside each request to widen overlap.
+        """
+        self.pages = pages
+        self.tracker = tracker
+        self.delay = delay
+
+    async def handle_async_request(self, request):
+        """Serve the fixture page for the requested URL."""
+        if self.tracker is not None:
+            self.tracker["inflight"] += 1
+            self.tracker["max"] = max(self.tracker["max"], self.tracker["inflight"])
+        try:
+            if self.delay:
+                await asyncio.sleep(self.delay)
+            url = str(request.url)
+            html = self.pages.get(url)
+            if html is None:
+                return httpx.Response(404, text="not found")
+            return httpx.Response(
+                200, headers={"content-type": "text/html"}, text=html
+            )
+        finally:
+            if self.tracker is not None:
+                self.tracker["inflight"] -= 1
+
+
+class SyncResp:
+    """Minimal stand-in for a requests.Response used by the sync path."""
+
+    def __init__(self, text):
+        self.status_code = 200 if text is not None else 404
+        self.text = text or ""
+        self.headers = {"content-type": "text/html"}
+
+
+# A small interlinked fixture site reachable entirely from the root.
+SITE = {
+    "http://site.test/": (
+        '<html><body><a href="/a">a</a><a href="/b">b</a></body></html>'
+    ),
+    "http://site.test/a": '<html><body><a href="/c">c</a></body></html>',
+    "http://site.test/b": (
+        '<html><body><a href="/c">c</a><a href="/a">a</a></body></html>'
+    ),
+    "http://site.test/c": "<html><body>leaf</body></html>",
+}
+
+
+def _make_scraper(db, **kwargs):
+    """Build a Scraper rooted at the fixture site with test defaults."""
+    params = dict(
+        base_url="http://site.test",
+        exclude_patterns=[],
+        include_url_patterns=[],
+        db_manager=db,
+    )
+    params.update(kwargs)
+    return Scraper(**params)
+
+
+def _corpus(db):
+    """Return the scraped corpus as a set of (url, content) pairs."""
+    return {(url, content) for url, content, _ in db.get_all_pages()}
+
+
+def test_async_sync_parity(monkeypatch):
+    """Sync (concurrency=1) and async (concurrency=5) yield an identical corpus."""
+    # Deterministic scrape: content is simply the page HTML.
+    monkeypatch.setattr(
+        Scraper, "scrape_page", lambda self, html, url: (html, {"url": url})
+    )
+
+    # Synchronous crawl.
+    sync_db = DatabaseManager(":memory:")
+    sync_scraper = _make_scraper(sync_db)
+    monkeypatch.setattr(
+        sync_scraper.session, "get", lambda url, **k: SyncResp(SITE.get(url))
+    )
+    sync_scraper.start_scraping(url="http://site.test/")
+
+    # Asynchronous crawl with concurrency 5 over the same fixture.
+    async_db = DatabaseManager(":memory:")
+    async_scraper = _make_scraper(async_db, concurrency=5)
+    monkeypatch.setattr(
+        async_scraper,
+        "_make_async_client",
+        lambda: httpx.AsyncClient(
+            transport=FixtureTransport(SITE), follow_redirects=True
+        ),
+    )
+    asyncio.run(async_scraper.start_scraping_async(url="http://site.test/"))
+
+    sync_corpus = _corpus(sync_db)
+    async_corpus = _corpus(async_db)
+
+    # Both crawled the full reachable set, identically.
+    assert {url for url, _ in sync_corpus} == set(SITE.keys())
+    assert sync_corpus == async_corpus
+
+
+def test_async_issues_overlapping_requests(monkeypatch):
+    """concurrency>1 actually fetches in parallel; concurrency=1 never overlaps."""
+    monkeypatch.setattr(
+        Scraper, "scrape_page", lambda self, html, url: (html, {"url": url})
+    )
+
+    hub = {
+        "http://hub.test/": "".join(
+            f'<a href="/p{i}">p{i}</a>' for i in range(1, 6)
+        ),
+    }
+    hub.update({f"http://hub.test/p{i}": "<html>leaf</html>" for i in range(1, 6)})
+
+    # Concurrent run: a batch of 5 leaf pages should overlap.
+    tracker = {"inflight": 0, "max": 0}
+    db = DatabaseManager(":memory:")
+    scraper = _make_scraper(db, base_url="http://hub.test", concurrency=5)
+    monkeypatch.setattr(
+        scraper,
+        "_make_async_client",
+        lambda: httpx.AsyncClient(
+            transport=FixtureTransport(hub, tracker=tracker, delay=0.02),
+            follow_redirects=True,
+        ),
+    )
+    asyncio.run(scraper.start_scraping_async(url="http://hub.test/"))
+
+    assert len(db.get_all_pages()) == 6  # hub + 5 leaves
+    assert tracker["max"] >= 2  # genuine overlap occurred
+
+    # Serial run: concurrency=1 must never have more than one request in flight.
+    tracker1 = {"inflight": 0, "max": 0}
+    db1 = DatabaseManager(":memory:")
+    scraper1 = _make_scraper(db1, base_url="http://hub.test", concurrency=1)
+    monkeypatch.setattr(
+        scraper1,
+        "_make_async_client",
+        lambda: httpx.AsyncClient(
+            transport=FixtureTransport(hub, tracker=tracker1, delay=0.01),
+            follow_redirects=True,
+        ),
+    )
+    asyncio.run(scraper1.start_scraping_async(url="http://hub.test/"))
+    assert tracker1["max"] == 1
+
+
+def test_aget_with_retry_succeeds_after_429(monkeypatch):
+    """The async retry helper retries a 429 and returns the eventual 200."""
+    scraper = Scraper(
+        base_url="http://x",
+        exclude_patterns=[],
+        include_url_patterns=[],
+        db_manager=_DummyDB(),
+        max_retries=2,
+    )
+
+    calls = {"n": 0}
+
+    class _RetryTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(429, headers={"content-type": "text/html"})
+            return httpx.Response(
+                200, headers={"content-type": "text/html"}, text="ok"
+            )
+
+    async def _fast_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr("crawler_to_md.scraper.asyncio.sleep", _fast_sleep)
+
+    async def run():
+        async with httpx.AsyncClient(transport=_RetryTransport()) as client:
+            return await scraper._aget_with_retry(client, "http://x/")
+
+    response = asyncio.run(run())
+
+    assert response.status_code == 200
+    assert calls["n"] == 2  # one retry after the 429

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -386,6 +386,7 @@ def test_cli_overwrite_cache(monkeypatch, tmp_path):
     def fake_init(self, db_path):
         captured['exists'] = os.path.exists(db_path)
         self.conn = sqlite3.connect(':memory:')
+        self.create_tables()
 
     monkeypatch.setattr(DatabaseManager, '__init__', fake_init)
     monkeypatch.setattr(ExportManager, 'export_to_markdown', lambda *a, **k: None)
@@ -419,6 +420,7 @@ def test_cli_overwrite_cache_short_option(monkeypatch, tmp_path):
     def fake_init(self, db_path):
         captured['exists'] = os.path.exists(db_path)
         self.conn = sqlite3.connect(':memory:')
+        self.create_tables()
 
     monkeypatch.setattr(DatabaseManager, '__init__', fake_init)
     monkeypatch.setattr(ExportManager, 'export_to_markdown', lambda *a, **k: None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,7 @@ def test_cli_proxy_option(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        **kwargs,
     ):
         """
         Fake initializer to capture proxy argument.
@@ -110,6 +111,7 @@ def test_cli_proxy_short_option(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        **kwargs,
     ):
         """
         Fake initializer to capture proxy argument.
@@ -155,6 +157,7 @@ def test_cli_socks_proxy(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        **kwargs,
     ):
         """
         Fake initializer to capture proxy argument.
@@ -229,6 +232,7 @@ def test_cli_include_exclude_options(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        **kwargs,
     ):
         """
         Fake initializer to capture include/exclude arguments.
@@ -286,6 +290,7 @@ def test_cli_include_exclude_short_options(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        **kwargs,
     ):
         """
         Capture include and exclude selectors from short options.
@@ -343,6 +348,7 @@ def test_cli_include_url_option(monkeypatch, tmp_path):
         proxy=None,
         include_filters=None,
         exclude_filters=None,
+        **kwargs,
     ):
         """
         Capture include URL patterns argument.

--- a/tests/test_crawl_intelligence.py
+++ b/tests/test_crawl_intelligence.py
@@ -1,0 +1,404 @@
+"""Tests for Wave 2a crawl-intelligence features.
+
+Covers robots.txt compliance, sitemap seeding, custom headers/cookies/auth,
+non-HTML (allow-types) ingestion, and the clear missing-extra error paths for
+readability extraction and JS rendering. Each behavior is asserted on both the
+configuration and, where relevant, the actual outgoing request.
+"""
+
+import asyncio
+import sys
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from crawler_to_md import cli
+from crawler_to_md.database_manager import DatabaseManager
+from crawler_to_md.export_manager import ExportManager
+from crawler_to_md.scraper import Scraper
+
+
+class _DummyDB:
+    """Minimal DatabaseManager stand-in for tests that never touch the DB."""
+
+    def __del__(self):
+        pass
+
+
+class Resp:
+    """Minimal response stand-in exposing the consumed response interface."""
+
+    def __init__(self, text="", status=200, content_type="text/html", content=None):
+        """
+        Args:
+            text (str): Response body decoded as text.
+            status (int): HTTP status code.
+            content_type (str): Value for the ``content-type`` header.
+            content (bytes | None): Raw body; defaults to ``text`` encoded.
+        """
+        self.status_code = status
+        self.text = text
+        self.headers = {"content-type": content_type}
+        self.content = content if content is not None else text.encode("utf-8")
+
+
+def _make_scraper(db, **kwargs):
+    """Build a Scraper rooted at example.com with test defaults."""
+    params = dict(
+        base_url="http://example.com",
+        exclude_patterns=[],
+        include_url_patterns=[],
+        db_manager=db,
+    )
+    params.update(kwargs)
+    return Scraper(**params)
+
+
+ROBOTS_BODY = "User-agent: *\nDisallow: /private"
+
+ROBOTS_SITE = {
+    "http://example.com/robots.txt": ROBOTS_BODY,
+    "http://example.com/": (
+        '<html><body><a href="/public">p</a>'
+        '<a href="/private">x</a></body></html>'
+    ),
+    "http://example.com/public": "<html><body>public</body></html>",
+    "http://example.com/private": "<html><body>private</body></html>",
+}
+
+
+def _robots_site_get(url, **kwargs):
+    """Serve the robots fixture site, 404 for unknown URLs."""
+    body = ROBOTS_SITE.get(url)
+    if body is None:
+        return Resp(status=404, content=b"")
+    return Resp(text=body, status=200)
+
+
+def test_robots_blocks_disallowed_path(monkeypatch):
+    """A path disallowed by robots.txt is never scraped (default behavior)."""
+    db = DatabaseManager(":memory:")
+    scraper = _make_scraper(db)
+    monkeypatch.setattr(scraper.session, "get", _robots_site_get)
+    monkeypatch.setattr(
+        Scraper, "scrape_page", lambda self, html, url: (html, {"url": url})
+    )
+
+    scraper.start_scraping(url="http://example.com/")
+
+    scraped = {url for url, _, _ in db.get_all_pages()}
+    assert "http://example.com/public" in scraped
+    assert "http://example.com/private" not in scraped
+
+
+def test_ignore_robots_overrides_disallow(monkeypatch):
+    """--ignore-robots crawls a path that robots.txt would otherwise block."""
+    db = DatabaseManager(":memory:")
+    scraper = _make_scraper(db, ignore_robots=True)
+    monkeypatch.setattr(scraper.session, "get", _robots_site_get)
+    monkeypatch.setattr(
+        Scraper, "scrape_page", lambda self, html, url: (html, {"url": url})
+    )
+
+    scraper.start_scraping(url="http://example.com/")
+
+    scraped = {url for url, _, _ in db.get_all_pages()}
+    assert "http://example.com/private" in scraped
+
+
+def test_robots_allowed_helper(monkeypatch):
+    """The robots helper allows/denies individual URLs per the rules."""
+    db = _DummyDB()
+    scraper = _make_scraper(db)
+    monkeypatch.setattr(scraper.session, "get", _robots_site_get)
+
+    assert scraper._robots_allowed("http://example.com/public") is True
+    assert scraper._robots_allowed("http://example.com/private/x") is False
+
+
+SITEMAP_XML = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+    "<url><loc>http://example.com/a</loc></url>"
+    "<url><loc>http://example.com/b</loc></url>"
+    "</urlset>"
+)
+
+
+def test_sitemap_seeds_frontier(monkeypatch):
+    """Sitemap <loc> URLs are parsed, validated, and seeded into the frontier."""
+    db = DatabaseManager(":memory:")
+    scraper = _make_scraper(db, sitemap=True)
+
+    def fake_get(url, **kwargs):
+        assert url == "http://example.com/sitemap.xml"
+        return Resp(text=SITEMAP_XML)
+
+    monkeypatch.setattr(scraper.session, "get", fake_get)
+
+    seeded = scraper._seed_from_sitemap()
+
+    assert seeded == 2
+    urls = {url for url, _ in db.get_unvisited_links()}
+    assert "http://example.com/a" in urls
+    assert "http://example.com/b" in urls
+
+
+def test_sitemap_index_followed(monkeypatch):
+    """A sitemap index is followed to its child sitemaps to collect URLs."""
+    db = DatabaseManager(":memory:")
+    scraper = _make_scraper(db, sitemap=True)
+
+    index_xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        "<sitemap><loc>http://example.com/sm1.xml</loc></sitemap>"
+        "</sitemapindex>"
+    )
+    child_xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        "<url><loc>http://example.com/c</loc></url>"
+        "</urlset>"
+    )
+    mapping = {
+        "http://example.com/sitemap.xml": index_xml,
+        "http://example.com/sm1.xml": child_xml,
+    }
+
+    def fake_get(url, **kwargs):
+        body = mapping.get(url)
+        if body is None:
+            return Resp(status=404, content=b"")
+        return Resp(text=body)
+
+    monkeypatch.setattr(scraper.session, "get", fake_get)
+
+    scraper._seed_from_sitemap()
+
+    urls = {url for url, _ in db.get_unvisited_links()}
+    assert "http://example.com/c" in urls
+
+
+def test_sitemap_tolerates_missing(monkeypatch):
+    """A missing/non-200 sitemap seeds nothing and does not raise."""
+    db = DatabaseManager(":memory:")
+    scraper = _make_scraper(db, sitemap=True)
+    monkeypatch.setattr(
+        scraper.session, "get", lambda url, **k: Resp(status=404, content=b"")
+    )
+
+    assert scraper._seed_from_sitemap() == 0
+    assert db.get_links_count() == 0
+
+
+def test_custom_headers_cookie_auth_configured():
+    """UA, headers, cookies, and basic auth are applied to the sync session."""
+    db = _DummyDB()
+    scraper = _make_scraper(
+        db,
+        user_agent="MyUA/9.9",
+        headers=["X-Test: yes"],
+        cookies=["session=abc"],
+        auth="alice:secret",
+    )
+
+    assert scraper.session.headers["User-Agent"] == "MyUA/9.9"
+    assert scraper.session.headers["X-Test"] == "yes"
+    assert scraper.session.cookies.get("session") == "abc"
+    assert scraper.session.auth == ("alice", "secret")
+
+
+def test_custom_headers_sent_on_request():
+    """The configured UA/header/cookie/auth are actually present on the wire."""
+    db = _DummyDB()
+    scraper = _make_scraper(
+        db,
+        user_agent="MyUA/9.9",
+        headers=["X-Test: yes"],
+        cookies=["session=abc"],
+        auth="alice:secret",
+    )
+
+    captured = {}
+
+    class CaptureTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request):
+            captured["ua"] = request.headers.get("user-agent")
+            captured["xtest"] = request.headers.get("x-test")
+            captured["cookie"] = request.headers.get("cookie")
+            captured["auth"] = request.headers.get("authorization")
+            return httpx.Response(200, text="ok")
+
+    async def run():
+        async with httpx.AsyncClient(
+            transport=CaptureTransport(),
+            headers=scraper._headers,
+            cookies=scraper._cookies,
+            auth=scraper._auth,
+        ) as client:
+            await client.get("http://example.com/")
+
+    asyncio.run(run())
+
+    assert captured["ua"] == "MyUA/9.9"
+    assert captured["xtest"] == "yes"
+    assert "session=abc" in (captured["cookie"] or "")
+    assert (captured["auth"] or "").startswith("Basic ")
+
+
+def test_allow_types_lets_pdf_through(monkeypatch):
+    """A PDF content-type is ingested via MarkItDown when in --allow-types."""
+    db = DatabaseManager(":memory:")
+    scraper = _make_scraper(db, allow_types=["application/pdf"])
+
+    def fake_get(url, **kwargs):
+        if url.endswith("robots.txt"):
+            return Resp(status=404, content=b"")
+        return Resp(
+            status=200,
+            content_type="application/pdf",
+            content=b"%PDF-1.4",
+            text="",
+        )
+
+    monkeypatch.setattr(scraper.session, "get", fake_get)
+
+    with patch("crawler_to_md.scraper.MarkItDown") as mock_markdown:
+        mock_markdown.return_value.convert.return_value = "PDF TEXT"
+        scraper.start_scraping(url="http://example.com/doc.pdf")
+
+    pages = db.get_all_pages()
+    assert len(pages) == 1
+    assert pages[0][0] == "http://example.com/doc.pdf"
+    assert pages[0][1] == "PDF TEXT"
+
+
+def test_disallowed_content_type_skipped(monkeypatch):
+    """A non-HTML type not in --allow-types is skipped, not stored."""
+    db = DatabaseManager(":memory:")
+    scraper = _make_scraper(db)  # no allow_types
+
+    def fake_get(url, **kwargs):
+        if url.endswith("robots.txt"):
+            return Resp(status=404, content=b"")
+        return Resp(status=200, content_type="application/pdf", content=b"%PDF")
+
+    monkeypatch.setattr(scraper.session, "get", fake_get)
+
+    scraper.start_scraping(url="http://example.com/doc.pdf")
+
+    assert db.get_all_pages() == []
+
+
+def _block_import(monkeypatch, prefix):
+    """Force ImportError for any module whose name starts with ``prefix``."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == prefix or name.startswith(prefix + "."):
+            raise ImportError(f"blocked: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_readability_missing_extra_clear_error(monkeypatch):
+    """Readability extraction with trafilatura missing raises a clear error."""
+    db = _DummyDB()
+    scraper = _make_scraper(db, extract="readability")
+    _block_import(monkeypatch, "trafilatura")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        scraper.scrape_page("<html><body>hi</body></html>", "http://example.com/")
+
+    message = str(excinfo.value).lower()
+    assert "readability" in message
+    assert "pip install" in message
+
+
+def test_render_missing_extra_clear_error_sync(monkeypatch):
+    """Sync rendering with playwright missing raises a clear, actionable error."""
+    db = _DummyDB()
+    scraper = _make_scraper(db, render=True)
+    _block_import(monkeypatch, "playwright")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        scraper._render_sync("http://example.com/")
+
+    message = str(excinfo.value).lower()
+    assert "render" in message
+    assert "pip install" in message
+
+
+def test_render_missing_extra_clear_error_async(monkeypatch):
+    """Async rendering with playwright missing raises a clear, actionable error."""
+    db = _DummyDB()
+    scraper = _make_scraper(db, render=True)
+    _block_import(monkeypatch, "playwright")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(scraper._render_async("http://example.com/"))
+
+    assert "render" in str(excinfo.value).lower()
+
+
+def test_cli_passes_crawl_intelligence_flags(monkeypatch, tmp_path):
+    """All new CLI flags are wired through to the Scraper constructor."""
+    captured = {}
+
+    def fake_init(
+        self,
+        base_url,
+        exclude_patterns,
+        include_url_patterns,
+        db_manager,
+        **kwargs,
+    ):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(Scraper, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
+
+    cache_folder = tmp_path / "cache"
+    args = [
+        "prog",
+        "--url",
+        "http://example.com",
+        "--output-folder",
+        str(tmp_path),
+        "--cache-folder",
+        str(cache_folder),
+        "--ignore-robots",
+        "--user-agent",
+        "UA/1.0",
+        "--sitemap",
+        "--extract",
+        "readability",
+        "--render",
+        "--header",
+        "X-A: 1",
+        "--cookie",
+        "c=1",
+        "--auth",
+        "u:p",
+        "--allow-types",
+        "application/pdf",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    cli.main()
+
+    assert captured["ignore_robots"] is True
+    assert captured["user_agent"] == "UA/1.0"
+    assert captured["sitemap"] is True
+    assert captured["extract"] == "readability"
+    assert captured["render"] is True
+    assert captured["headers"] == ["X-A: 1"]
+    assert captured["cookies"] == ["c=1"]
+    assert captured["auth"] == "u:p"
+    assert captured["allow_types"] == ["application/pdf"]

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -15,7 +15,7 @@ def test_database_operations():
         # Insert link and verify count
         assert db.insert_link('http://example.com') is True
         assert db.get_links_count() == 1
-        assert db.get_unvisited_links() == [('http://example.com',)]
+        assert db.get_unvisited_links() == [('http://example.com', 0)]
 
         # Mark link visited
         db.mark_link_visited('http://example.com')
@@ -37,7 +37,7 @@ def test_insert_link_duplicates_and_list():
     assert db.insert_link(['http://b', 'http://a']) is True
     # total links should be 2
     assert db.get_links_count() == 2
-    assert set(db.get_unvisited_links()) == {('http://a',), ('http://b',)}
+    assert set(db.get_unvisited_links()) == {('http://a', 0), ('http://b', 0)}
 
 
 def test_context_manager_closes_connection():
@@ -67,3 +67,77 @@ def test_close_is_idempotent():
     # A second close must be a no-op rather than an error.
     db.close()
     assert db.conn is None
+
+
+def test_insert_page_upsert_only_rewrites_on_change():
+    """
+    insert_page upserts: new content writes, identical content is a no-op.
+
+    The return value reports whether content was (re)written, and metadata is
+    only rewritten when the content hash changes (content drives the hash).
+    """
+    db = DatabaseManager(':memory:')
+
+    # New page -> written.
+    assert db.insert_page('http://a', 'v1', '{"k": 1}') is True
+    assert db.get_page('http://a')[1] == 'v1'
+
+    # Same content -> no rewrite, even if metadata differs.
+    assert db.insert_page('http://a', 'v1', '{"k": 999}') is False
+    assert db.get_page('http://a')[1] == 'v1'
+    assert db.get_page('http://a')[2] == '{"k": 1}'  # metadata unchanged
+
+    # Changed content -> rewritten, metadata updated too.
+    assert db.insert_page('http://a', 'v2', '{"k": 2}') is True
+    assert db.get_page('http://a')[1] == 'v2'
+    assert db.get_page('http://a')[2] == '{"k": 2}'
+
+
+def test_insert_page_always_refreshes_fetched_at():
+    """fetched_at is set on insert and refreshed even when content is unchanged."""
+    db = DatabaseManager(':memory:')
+    db.insert_page('http://a', 'v1', '{}')
+    first_fetched = db.get_page('http://a')[4]
+    assert first_fetched is not None
+    # Re-insert identical content; fetched_at must still be populated.
+    db.insert_page('http://a', 'v1', '{}')
+    assert db.get_page('http://a')[4] is not None
+
+
+def test_migration_adds_columns_to_legacy_db(tmp_path):
+    """
+    Opening a pre-Wave-1 database adds the new columns without losing data.
+
+    A legacy schema (no content_hash/fetched_at/depth) is created directly,
+    then opened through DatabaseManager which must migrate it additively.
+    """
+    db_path = str(tmp_path / 'legacy.sqlite')
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE pages (url TEXT PRIMARY KEY, content TEXT, metadata TEXT)"
+    )
+    conn.execute("CREATE TABLE links (url TEXT PRIMARY KEY, visited BOOLEAN)")
+    conn.execute(
+        "INSERT INTO pages (url, content, metadata) VALUES "
+        "('http://a', 'old', '{}')"
+    )
+    conn.execute("INSERT INTO links (url, visited) VALUES ('http://a', 0)")
+    conn.commit()
+    conn.close()
+
+    db = DatabaseManager(db_path)
+    try:
+        page_cols = {r[1] for r in db.conn.execute("PRAGMA table_info(pages)")}
+        link_cols = {r[1] for r in db.conn.execute("PRAGMA table_info(links)")}
+        assert {'content_hash', 'fetched_at'} <= page_cols
+        assert 'depth' in link_cols
+
+        # Existing data is preserved.
+        assert db.get_page('http://a')[1] == 'old'
+        assert db.get_unvisited_links() == [('http://a', 0)]
+
+        # Upsert works against the migrated legacy row (hash was NULL).
+        assert db.insert_page('http://a', 'old', '{}') is True
+        assert db.insert_page('http://a', 'old', '{}') is False
+    finally:
+        db.close()

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -1,5 +1,8 @@
 import os
+import sqlite3
 import tempfile
+
+import pytest
 
 from crawler_to_md.database_manager import DatabaseManager
 
@@ -35,3 +38,32 @@ def test_insert_link_duplicates_and_list():
     # total links should be 2
     assert db.get_links_count() == 2
     assert set(db.get_unvisited_links()) == {('http://a',), ('http://b',)}
+
+
+def test_context_manager_closes_connection():
+    """
+    Using DatabaseManager as a context manager closes the connection on exit.
+
+    Inside the ``with`` block the database is usable; once the block exits the
+    underlying connection is closed (``self.conn`` set to ``None``) and any
+    further query raises, proving the resource was released.
+    """
+    with DatabaseManager(':memory:') as db:
+        assert db.insert_link('http://example.com') is True
+        assert db.get_links_count() == 1
+        conn = db.conn
+        assert conn is not None
+
+    # After the context exits the connection is released.
+    assert db.conn is None
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.execute("SELECT 1")
+
+
+def test_close_is_idempotent():
+    """Calling ``close`` multiple times is safe and does not raise."""
+    db = DatabaseManager(':memory:')
+    db.close()
+    # A second close must be a no-op rather than an error.
+    db.close()
+    assert db.conn is None

--- a/tests/test_export_manager.py
+++ b/tests/test_export_manager.py
@@ -97,6 +97,50 @@ def test_concatenate_skips_none_content():
     assert 'URL: http://b' in content
 
 
+def test_concatenate_markdown_multipage_single_cleanup():
+    """
+    Multi-page concatenation must run ``_cleanup_markdown`` exactly once.
+
+    The cleanup pass previously ran inside the per-page loop (O(n^2)); it now
+    runs a single time after the loop. This test asserts both that the cleanup
+    is invoked exactly once regardless of page count and that the resulting
+    document is correct (no runs of 3+ newlines, all pages present and ordered).
+    """
+    db = DatabaseManager(':memory:')
+    # Content with deliberate excessive blank lines to exercise cleanup.
+    db.insert_page('http://a', '# A\n\n\n\nAlpha', json.dumps({'k': 'va'}))
+    db.insert_page('http://b', '# B\n\n\n\nBravo', json.dumps({'k': 'vb'}))
+    db.insert_page('http://c', '# C\n\n\n\nCharlie', json.dumps({'k': 'vc'}))
+    exporter = ExportManager(db, title='Head')
+
+    call_count = {'n': 0}
+    original_cleanup = exporter._cleanup_markdown
+
+    def counting_cleanup(content):
+        """Wrap the real cleanup to count how many times it runs."""
+        call_count['n'] += 1
+        return original_cleanup(content)
+
+    exporter._cleanup_markdown = counting_cleanup
+    result = exporter._concatenate_markdown(db.get_all_pages())
+
+    # Single cleanup pass, not one per page.
+    assert call_count['n'] == 1
+
+    # Output correctness: title, every page, no excessive newline runs.
+    assert result.startswith('# Head')
+    for url, marker in (
+        ('http://a', 'Alpha'),
+        ('http://b', 'Bravo'),
+        ('http://c', 'Charlie'),
+    ):
+        assert f'URL: {url}' in result
+        assert marker in result
+    assert '\n\n\n' not in result
+    # Pages preserved in insertion order.
+    assert result.index('Alpha') < result.index('Bravo') < result.index('Charlie')
+
+
 def test_export_to_json_skips_none(tmp_path):
     db = DatabaseManager(':memory:')
     db.insert_page('http://a', None, '{}')

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,61 @@
+import pytest
+
+from crawler_to_md import mcp_server
+from crawler_to_md.core import CrawlResult, CrawlStats
+
+
+def test_mcp_missing_extra(monkeypatch):
+    """Building the server without the ``mcp`` extra raises a clear error."""
+
+    def boom():
+        raise RuntimeError(mcp_server.MCP_MISSING_MESSAGE)
+
+    monkeypatch.setattr(mcp_server, "_import_fastmcp", boom)
+    with pytest.raises(RuntimeError, match=r"crawler-to-md\[mcp\]"):
+        mcp_server.build_server()
+
+
+def test_mcp_crawl_tool(monkeypatch):
+    """The ``crawl`` tool callable returns serialisable pages and stats."""
+    fake = CrawlResult(
+        pages=[{"url": "http://x", "content": "# Hi", "metadata": {}}],
+        stats=CrawlStats(links_discovered=1, pages_scraped=1, pages_stored=1),
+    )
+    monkeypatch.setattr(mcp_server, "crawl", lambda url, **options: fake)
+
+    result = mcp_server.crawl_tool("http://x")
+    assert result["pages"][0]["content"] == "# Hi"
+    assert result["stats"]["pages_stored"] == 1
+
+
+def test_mcp_fetch_as_markdown(monkeypatch):
+    """``fetch_as_markdown`` returns content and bounds the crawl to one page."""
+    fake = CrawlResult(
+        pages=[{"url": "http://x", "content": "# Hi", "metadata": {}}],
+        stats=CrawlStats(),
+    )
+    captured = {}
+
+    def fake_crawl(url, **options):
+        captured.update(options)
+        return fake
+
+    monkeypatch.setattr(mcp_server, "crawl", fake_crawl)
+    assert mcp_server.fetch_as_markdown("http://x") == "# Hi"
+    assert captured["max_pages"] == 1
+    assert captured["max_depth"] == 0
+
+
+def test_mcp_fetch_as_markdown_no_content(monkeypatch):
+    """``fetch_as_markdown`` raises when no content could be fetched."""
+    fake = CrawlResult(pages=[], stats=CrawlStats())
+    monkeypatch.setattr(mcp_server, "crawl", lambda url, **options: fake)
+    with pytest.raises(RuntimeError):
+        mcp_server.fetch_as_markdown("http://x")
+
+
+def test_mcp_build_server_with_sdk():
+    """When the SDK is installed, the server constructs in-process (smoke test)."""
+    pytest.importorskip("mcp")
+    server = mcp_server.build_server()
+    assert server is not None

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,285 @@
+"""
+Tests for the Wave 2.5 entry-point-based plugin system.
+
+Covers protocol conformance, defensive registry discovery, first-party
+implementations for every group, an example third-party-style formatter
+discovered through an injected entry point and exercised end-to-end, and parity
+between the registry-driven export path and the direct ``ExportManager``
+methods (proving zero behaviour change).
+"""
+
+import json
+from importlib.metadata import EntryPoint
+
+import pytest
+
+from crawler_to_md import plugins
+from crawler_to_md.database_manager import DatabaseManager
+from crawler_to_md.export_manager import ExportManager
+from crawler_to_md.plugins import (
+    Fetcher,
+    Filter,
+    Formatter,
+    NoOpProcessor,
+    PluginRegistry,
+    Processor,
+    RequestsFetcher,
+    UrlPatternFilter,
+    get_registry,
+)
+from crawler_to_md.scraper import Scraper
+
+FIRST_PARTY_FORMATTERS = {
+    "markdown",
+    "json",
+    "jsonl",
+    "llms",
+    "individual",
+    "chunks",
+    "vectors",
+}
+
+
+def _populated_db():
+    """Build an in-memory database with two non-empty pages."""
+    db = DatabaseManager(":memory:")
+    db.insert_page(
+        "http://example.com/a",
+        "# Alpha\n\nThe quick brown fox.",
+        json.dumps({"title": "Alpha Page"}),
+    )
+    db.insert_page(
+        "http://example.com/b",
+        "# Bravo\n\nAnother paragraph here.",
+        json.dumps({"title": "Bravo Page"}),
+    )
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Registry discovery of first-party plugins
+# ---------------------------------------------------------------------------
+
+
+def test_registry_discovers_first_party_formatters():
+    registry = PluginRegistry()
+    formatters = registry.discover("formatters")
+    assert FIRST_PARTY_FORMATTERS <= set(formatters)
+    # Every discovered formatter conforms to the Formatter protocol.
+    for obj in formatters.values():
+        instance = obj() if isinstance(obj, type) else obj
+        assert isinstance(instance, Formatter)
+
+
+def test_each_group_has_first_party_impl():
+    registry = PluginRegistry()
+    assert isinstance(registry.create("filters", "url-pattern"), Filter)
+    assert isinstance(registry.create("processors", "noop"), Processor)
+    assert isinstance(registry.create("fetchers", "requests"), Fetcher)
+
+
+def test_unknown_group_raises():
+    registry = PluginRegistry()
+    with pytest.raises(KeyError):
+        registry.discover("nonsense")
+
+
+def test_get_returns_none_for_unknown_name():
+    registry = PluginRegistry()
+    assert registry.get("formatters", "does-not-exist") is None
+
+
+def test_create_unknown_name_raises():
+    registry = PluginRegistry()
+    with pytest.raises(KeyError):
+        registry.create("formatters", "does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# Defensive discovery
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_tolerates_entry_point_failure(monkeypatch):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("metadata exploded")
+
+    monkeypatch.setattr(plugins, "entry_points", _boom)
+    registry = PluginRegistry()
+    # Built-ins remain available and no exception escapes.
+    formatters = registry.discover("formatters")
+    assert FIRST_PARTY_FORMATTERS <= set(formatters)
+
+
+def test_discovery_skips_broken_plugin(monkeypatch):
+    broken = EntryPoint(
+        name="broken",
+        value="crawler_to_md.does_not_exist:Missing",
+        group="crawler_to_md.formatters",
+    )
+
+    def _fake_entry_points(*, group):
+        return [broken] if group == "crawler_to_md.formatters" else []
+
+    monkeypatch.setattr(plugins, "entry_points", _fake_entry_points)
+    registry = PluginRegistry()
+    formatters = registry.discover("formatters", refresh=True)
+    # The broken plugin is skipped; built-ins survive.
+    assert "broken" not in formatters
+    assert FIRST_PARTY_FORMATTERS <= set(formatters)
+
+
+def test_discovery_is_cached(monkeypatch):
+    calls = {"n": 0}
+
+    def _counting_entry_points(*, group):
+        calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(plugins, "entry_points", _counting_entry_points)
+    registry = PluginRegistry()
+    registry.discover("formatters")
+    registry.discover("formatters")
+    assert calls["n"] == 1
+    registry.discover("formatters", refresh=True)
+    assert calls["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Third-party-style formatter discovered via an injected entry point
+# ---------------------------------------------------------------------------
+
+
+def test_entry_point_formatter_discovered_and_used_end_to_end(monkeypatch, tmp_path):
+    sample_ep = EntryPoint(
+        name="sample",
+        value="tests.sample_plugin:SampleFormatter",
+        group="crawler_to_md.formatters",
+    )
+
+    def _fake_entry_points(*, group):
+        return [sample_ep] if group == "crawler_to_md.formatters" else []
+
+    monkeypatch.setattr(plugins, "entry_points", _fake_entry_points)
+
+    registry = PluginRegistry()
+    formatters = registry.discover("formatters", refresh=True)
+    # Discovered alongside the built-ins.
+    assert "sample" in formatters
+    assert FIRST_PARTY_FORMATTERS <= set(formatters)
+
+    # Used end-to-end through a real ExportManager.
+    db = _populated_db()
+    manager = ExportManager(db, title="Site")
+    formatter = registry.create("formatters", "sample")
+    out = tmp_path / "sample.txt"
+    count = formatter.export(manager, str(out))
+
+    assert count == 2
+    text = out.read_text(encoding="utf-8")
+    assert text.startswith("# sample-plugin export")
+    assert "http://example.com/a" in text
+    assert "http://example.com/b" in text
+
+
+# ---------------------------------------------------------------------------
+# First-party filter / fetcher behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_url_pattern_filter_matches_scraper():
+    db = DatabaseManager(":memory:")
+    scraper = Scraper(
+        base_url="http://example.com",
+        exclude_patterns=["/private"],
+        include_url_patterns=["/docs"],
+        db_manager=db,
+    )
+    plugin_filter = UrlPatternFilter.from_scraper(scraper)
+
+    candidates = [
+        "http://example.com/docs/intro",
+        "http://example.com/docs/private/secret",
+        "http://other.com/docs/intro",
+        "http://example.com/blog/post",
+        "http://example.com/docs/intro?utm_source=x",
+    ]
+    for url in candidates:
+        assert plugin_filter.is_allowed(url) == scraper.is_valid_link(url)
+
+
+def test_url_pattern_filter_default_allows_everything():
+    assert UrlPatternFilter().is_allowed("http://anything.example/x")
+
+
+def test_noop_processor_returns_html_unchanged():
+    processor = NoOpProcessor()
+    html = "<html><body>hi</body></html>"
+    assert processor.process(html, "http://example.com") == html
+
+
+def test_requests_fetcher_from_scraper_delegates(monkeypatch):
+    db = DatabaseManager(":memory:")
+    scraper = Scraper(
+        base_url="http://example.com",
+        exclude_patterns=[],
+        include_url_patterns=[],
+        db_manager=db,
+    )
+    sentinel = object()
+    captured = {}
+
+    def _fake_get_with_retry(url):
+        captured["url"] = url
+        return sentinel
+
+    monkeypatch.setattr(scraper, "_get_with_retry", _fake_get_with_retry)
+    fetcher = RequestsFetcher.from_scraper(scraper)
+    result = fetcher.fetch("http://example.com/page")
+
+    assert result is sentinel
+    assert captured["url"] == "http://example.com/page"
+
+
+# ---------------------------------------------------------------------------
+# Registry-driven export parity (zero behaviour change)
+# ---------------------------------------------------------------------------
+
+
+def test_export_with_markdown_matches_direct(tmp_path):
+    db = _populated_db()
+    manager = ExportManager(db, title="Site")
+
+    direct = tmp_path / "direct.md"
+    via_registry = tmp_path / "registry.md"
+    manager.export_to_markdown(str(direct))
+    manager.export_with("markdown", str(via_registry))
+
+    assert via_registry.read_text(encoding="utf-8") == direct.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_export_with_json_matches_direct(tmp_path):
+    db = _populated_db()
+    manager = ExportManager(db, title="Site")
+
+    direct = tmp_path / "direct.json"
+    via_registry = tmp_path / "registry.json"
+    manager.export_to_json(str(direct))
+    manager.export_with("json", str(via_registry))
+
+    assert json.loads(via_registry.read_text(encoding="utf-8")) == json.loads(
+        direct.read_text(encoding="utf-8")
+    )
+
+
+def test_export_with_unknown_formatter_raises(tmp_path):
+    db = _populated_db()
+    manager = ExportManager(db, title="Site")
+    with pytest.raises(KeyError):
+        manager.export_with("nope", str(tmp_path / "x"))
+
+
+def test_default_registry_is_shared():
+    assert get_registry() is plugins.registry

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -15,7 +15,7 @@ class DummyDB(DatabaseManager):
     def __del__(self):
         pass
 
-    def insert_link(self, url, visited=False):
+    def insert_link(self, url, visited=False, depth=0):
         return True
 
     def get_unvisited_links(self):
@@ -194,7 +194,7 @@ class ListDB(DummyDB):
         self.visited = set()
         self.pages = []
 
-    def insert_link(self, url, visited=False):
+    def insert_link(self, url, visited=False, depth=0):
         urls = url if isinstance(url, list) else [url]
         inserted = False
         for u in urls:
@@ -434,6 +434,7 @@ def test_start_scraping_survives_request_exception(monkeypatch):
         exclude_patterns=[],
         include_url_patterns=[],
         db_manager=db,
+        max_retries=0,
     )
 
     def boom(url, **kwargs):
@@ -467,3 +468,191 @@ def test_start_scraping_survives_request_exception(monkeypatch):
     assert ('http://example.com/page',) not in db.get_unvisited_links()
     assert db.get_visited_links_count() == 1
     assert db.pages == []
+
+
+class FakeResp:
+    """Minimal stand-in for ``requests.Response`` used in retry tests."""
+
+    def __init__(self, status_code, text='', headers=None):
+        self.status_code = status_code
+        self.text = text
+        self.headers = headers or {'content-type': 'text/html'}
+
+
+def _make_scraper(db, **kwargs):
+    """Build a Scraper with sensible test defaults."""
+    params = dict(
+        base_url='http://example.com',
+        exclude_patterns=[],
+        include_url_patterns=[],
+        db_manager=db,
+    )
+    params.update(kwargs)
+    return Scraper(**params)
+
+
+def test_get_with_retry_succeeds_after_429(monkeypatch):
+    """A 429 followed by a 200 should retry once and return the success."""
+    db = DummyDB()
+    scraper = _make_scraper(db, max_retries=3)
+
+    responses = [FakeResp(429), FakeResp(200, text='ok')]
+    calls = {'i': 0}
+
+    def fake_get(url, **kwargs):
+        resp = responses[calls['i']]
+        calls['i'] += 1
+        return resp
+
+    slept = []
+    monkeypatch.setattr(scraper.session, 'get', fake_get)
+    monkeypatch.setattr('crawler_to_md.scraper.time.sleep', lambda s: slept.append(s))
+
+    response = scraper._get_with_retry('http://example.com')
+
+    assert response.status_code == 200
+    assert calls['i'] == 2  # exactly one retry
+    assert len(slept) == 1  # one backoff slept between attempts
+
+
+def test_start_scraping_retries_429_then_scrapes(monkeypatch):
+    """The crawl loop scrapes a page once a 429 clears, not skipping it."""
+    db = ListDB()
+    scraper = _make_scraper(db, max_retries=3)
+
+    responses = [FakeResp(429), FakeResp(200, text='<html></html>')]
+    calls = {'i': 0}
+
+    def fake_get(url, **kwargs):
+        resp = responses[min(calls['i'], len(responses) - 1)]
+        calls['i'] += 1
+        return resp
+
+    monkeypatch.setattr(scraper.session, 'get', fake_get)
+    monkeypatch.setattr('crawler_to_md.scraper.time.sleep', lambda s: None)
+    monkeypatch.setattr(Scraper, 'fetch_links', lambda self, url, html=None: set())
+    monkeypatch.setattr(
+        Scraper, 'scrape_page', lambda self, html, url: ('# MD', {'url': url})
+    )
+
+    scraper.start_scraping(url='http://example.com/page')
+
+    # The page was eventually scraped (not skipped because of the initial 429).
+    assert db.pages and db.pages[0][0] == 'http://example.com/page'
+    assert db.get_visited_links_count() == 1
+
+
+def test_retry_after_header_respected(monkeypatch):
+    """A numeric Retry-After header dictates the backoff sleep duration."""
+    db = DummyDB()
+    scraper = _make_scraper(db, max_retries=2)
+
+    responses = [
+        FakeResp(503, headers={'content-type': 'text/html', 'Retry-After': '7'}),
+        FakeResp(200, text='ok'),
+    ]
+    calls = {'i': 0}
+
+    def fake_get(url, **kwargs):
+        resp = responses[calls['i']]
+        calls['i'] += 1
+        return resp
+
+    slept = []
+    monkeypatch.setattr(scraper.session, 'get', fake_get)
+    monkeypatch.setattr('crawler_to_md.scraper.time.sleep', lambda s: slept.append(s))
+
+    response = scraper._get_with_retry('http://example.com')
+
+    assert response.status_code == 200
+    assert slept == [7.0]
+
+
+def test_timeout_passed_through(monkeypatch):
+    """The configured timeout is forwarded to every session.get call."""
+    db = DummyDB()
+    scraper = _make_scraper(db, timeout=42)
+
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured.update(kwargs)
+        return FakeResp(200, text='ok')
+
+    monkeypatch.setattr(scraper.session, 'get', fake_get)
+    scraper._get_with_retry('http://example.com')
+
+    assert captured.get('timeout') == 42
+
+
+def test_max_pages_enforced(monkeypatch):
+    """No more than max_pages pages are scraped even when more are discovered."""
+    db = DatabaseManager(':memory:')
+    scraper = _make_scraper(db, max_pages=2)
+
+    html = (
+        '<html><body>'
+        '<a href="/p1">1</a><a href="/p2">2</a>'
+        '<a href="/p3">3</a><a href="/p4">4</a>'
+        '</body></html>'
+    )
+    monkeypatch.setattr(
+        scraper.session, 'get', lambda url, **k: FakeResp(200, text=html)
+    )
+    monkeypatch.setattr(
+        Scraper, 'scrape_page', lambda self, html, url: ('# MD', {'url': url})
+    )
+
+    scraper.start_scraping(url='http://example.com')
+
+    assert len(db.get_all_pages()) == 2
+
+
+def test_max_depth_limits_discovery(monkeypatch):
+    """max_depth=0 crawls only seeds; max_depth=1 discovers one level."""
+    html = '<html><body><a href="/child">c</a></body></html>'
+
+    db0 = DatabaseManager(':memory:')
+    scraper0 = _make_scraper(db0, max_depth=0)
+    monkeypatch.setattr(
+        scraper0.session, 'get', lambda url, **k: FakeResp(200, text=html)
+    )
+    monkeypatch.setattr(
+        Scraper, 'scrape_page', lambda self, html, url: ('# MD', {'url': url})
+    )
+    scraper0.start_scraping(url='http://example.com')
+    # Only the seed is ever inserted; the child is never discovered.
+    assert db0.get_links_count() == 1
+
+    db1 = DatabaseManager(':memory:')
+    scraper1 = _make_scraper(db1, max_depth=1)
+    monkeypatch.setattr(
+        scraper1.session, 'get', lambda url, **k: FakeResp(200, text=html)
+    )
+    scraper1.start_scraping(url='http://example.com')
+    # Seed (depth 0) plus its one discovered child (depth 1).
+    assert db1.get_links_count() == 2
+
+
+def test_max_time_stops_loop(monkeypatch):
+    """The crawl halts once max_time elapses, leaving discovered pages unscraped."""
+    db = DatabaseManager(':memory:')
+    scraper = _make_scraper(db, max_time=10)
+
+    html = '<html><body><a href="/p1">1</a><a href="/p2">2</a></body></html>'
+    monkeypatch.setattr(
+        scraper.session, 'get', lambda url, **k: FakeResp(200, text=html)
+    )
+    monkeypatch.setattr(
+        Scraper, 'scrape_page', lambda self, html, url: ('# MD', {'url': url})
+    )
+
+    # Fake monotonic-ish clock: start_time=0, crawl_start=0, first bound check
+    # 0 (under limit), second iteration's check 100 (over limit -> stop).
+    times = iter([0, 0, 0, 100])
+    monkeypatch.setattr('crawler_to_md.scraper.time.time', lambda: next(times, 100))
+
+    scraper.start_scraping(url='http://example.com')
+
+    # Only the seed page was scraped before the time bound tripped.
+    assert len(db.get_all_pages()) == 1

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -242,7 +242,7 @@ def test_start_scraping_process(monkeypatch):
         content = b'<html></html>'
         text = '<html></html>'
 
-    monkeypatch.setattr(scraper.session, 'get', lambda url: DummyResp())
+    monkeypatch.setattr(scraper.session, 'get', lambda url, **kwargs: DummyResp())
 
     class DummyTqdm:
         def __init__(self, *a, **k):
@@ -346,7 +346,7 @@ def test_start_scraping_excludes_invalid_urls(monkeypatch):
         content = b'<html></html>'
         text = '<html></html>'
 
-    monkeypatch.setattr(scraper.session, 'get', lambda url: DummyResp())
+    monkeypatch.setattr(scraper.session, 'get', lambda url, **kwargs: DummyResp())
 
     class DummyTqdm:
         def __init__(self, *a, **k):
@@ -393,7 +393,7 @@ def test_start_scraping_filters_discovered_links(monkeypatch):
         headers = {'content-type': 'text/html'}
         text = html
 
-    monkeypatch.setattr(scraper.session, 'get', lambda url: DummyResp())
+    monkeypatch.setattr(scraper.session, 'get', lambda url, **kwargs: DummyResp())
 
     monkeypatch.setattr(
         Scraper, 'scrape_page', lambda self, html, url: ('# MD', {'url': url})
@@ -414,3 +414,56 @@ def test_start_scraping_filters_discovered_links(monkeypatch):
     scraper.start_scraping(url='http://example.com')
 
     assert 'http://example.com/exclude/page' not in db.links
+
+
+def test_start_scraping_survives_request_exception(monkeypatch):
+    """
+    The crawl loop must not crash when ``session.get`` raises a network error.
+
+    A :class:`requests.RequestException` injected on the main fetch should be
+    caught: the offending link is marked as visited, no page is stored, and the
+    loop terminates cleanly instead of propagating the exception.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture used to patch network and
+            progress-bar dependencies.
+    """
+    db = ListDB()
+    scraper = Scraper(
+        base_url='http://example.com',
+        exclude_patterns=[],
+        include_url_patterns=[],
+        db_manager=db,
+    )
+
+    def boom(url, **kwargs):
+        raise requests.exceptions.ConnectionError("connection refused")
+
+    monkeypatch.setattr(scraper.session, 'get', boom)
+    monkeypatch.setattr(
+        Scraper, 'scrape_page', lambda self, html, url: ('# MD', {'url': url})
+    )
+
+    class DummyTqdm:
+        def __init__(self, *a, **k):
+            self.total = k.get('total', 0)
+
+        def update(self, n):
+            pass
+
+        def refresh(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(tqdm, 'tqdm', lambda *a, **k: DummyTqdm(*a, **k))
+
+    # Should not raise despite the injected network failure.
+    scraper.start_scraping(url='http://example.com/page')
+
+    # The failing link is marked visited so the loop terminates, and no page
+    # was scraped.
+    assert ('http://example.com/page',) not in db.get_unvisited_links()
+    assert db.get_visited_links_count() == 1
+    assert db.pages == []

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,3 +28,36 @@ def test_randomstring_special_chars():
 def test_url_to_filename_invalid():
     with pytest.raises(ValueError):
         utils.url_to_filename(123)
+
+
+def test_canonicalize_url_collapses_variants():
+    """Equivalent URLs (port/utm/query-order/fragment) collapse to one key."""
+    a = utils.canonicalize_url('http://Example.com:80/Path?utm_source=x&b=2&a=1#frag')
+    b = utils.canonicalize_url('http://example.com/Path?a=1&b=2')
+    assert a == b == 'http://example.com/Path?a=1&b=2'
+
+
+def test_canonicalize_url_root_trailing_slash():
+    """An empty root path and an explicit '/' root collapse to the same URL."""
+    assert utils.canonicalize_url('http://example.com') == utils.canonicalize_url(
+        'http://example.com/'
+    )
+    assert utils.canonicalize_url('http://example.com') == 'http://example.com/'
+
+
+def test_canonicalize_url_strips_default_https_port():
+    """The redundant default HTTPS port (443) is removed."""
+    assert utils.canonicalize_url('https://Example.com:443/') == 'https://example.com/'
+
+
+def test_canonicalize_url_drops_tracking_params_preserves_case():
+    """Tracking params are dropped while meaningful path case is preserved."""
+    result = utils.canonicalize_url('https://example.com/Docs?fbclid=zzz&gclid=q')
+    assert result == 'https://example.com/Docs'
+
+
+def test_canonicalize_url_non_default_port_preserved():
+    """A non-default port is kept (only 80/443 defaults are stripped)."""
+    assert utils.canonicalize_url('http://example.com:8080/x') == (
+        'http://example.com:8080/x'
+    )

--- a/tests/test_wave3_cli.py
+++ b/tests/test_wave3_cli.py
@@ -1,0 +1,183 @@
+import json
+import sys
+
+import pytest
+
+from crawler_to_md import cli, crawl, utils
+from crawler_to_md.database_manager import DatabaseManager
+from crawler_to_md.export_manager import ExportManager
+from crawler_to_md.scraper import Scraper
+
+
+def test_inject_default_subcommand_legacy():
+    """Bare/legacy invocations are routed to the implicit ``crawl`` subcommand."""
+    assert cli._inject_default_subcommand(["--url", "x"]) == ["crawl", "--url", "x"]
+    assert cli._inject_default_subcommand(["crawl", "--url", "x"]) == [
+        "crawl",
+        "--url",
+        "x",
+    ]
+    assert cli._inject_default_subcommand(["export", "--url", "x"]) == [
+        "export",
+        "--url",
+        "x",
+    ]
+    assert cli._inject_default_subcommand(["mcp"]) == ["mcp"]
+    assert cli._inject_default_subcommand([]) == ["crawl"]
+
+
+def test_cli_explicit_crawl_subcommand(monkeypatch, tmp_path):
+    """The explicit ``crawl`` subcommand exports like the legacy default path."""
+    calls = {"md": False, "json": False}
+    monkeypatch.setattr(
+        ExportManager,
+        "export_to_markdown",
+        lambda self, p: calls.__setitem__("md", True),
+    )
+    monkeypatch.setattr(
+        ExportManager,
+        "export_to_json",
+        lambda self, p: calls.__setitem__("json", True),
+    )
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+
+    args = [
+        "prog",
+        "crawl",
+        "--url",
+        "http://example.com",
+        "--output-folder",
+        str(tmp_path),
+        "--cache-folder",
+        str(tmp_path / "cache"),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    cli.main()
+    assert calls["md"] is True
+    assert calls["json"] is True
+
+
+def test_cli_config_file_applied_and_overridden(monkeypatch, tmp_path):
+    """Config-file values feed the crawl, and explicit CLI flags override them."""
+    captured = {}
+
+    def fake_init(
+        self,
+        base_url,
+        exclude_patterns,
+        include_url_patterns,
+        db_manager,
+        **kwargs,
+    ):
+        captured.clear()
+        captured.update(kwargs)
+
+    monkeypatch.setattr(Scraper, "__init__", fake_init)
+    monkeypatch.setattr(Scraper, "start_scraping", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_markdown", lambda *a, **k: None)
+    monkeypatch.setattr(ExportManager, "export_to_json", lambda *a, **k: None)
+
+    config_file = tmp_path / "crawler-to-md.toml"
+    config_file.write_text("max_pages = 7\nrate_limit = 12\n")
+
+    base = [
+        "prog",
+        "crawl",
+        "--url",
+        "http://example.com",
+        "--output-folder",
+        str(tmp_path),
+        "--cache-folder",
+        str(tmp_path / "cache"),
+        "--config",
+        str(config_file),
+    ]
+    monkeypatch.setattr(sys, "argv", base)
+    cli.main()
+    assert captured["max_pages"] == 7
+    assert captured["rate_limit"] == 12
+
+    monkeypatch.setattr(sys, "argv", base + ["--max-pages", "3"])
+    cli.main()
+    assert captured["max_pages"] == 3
+    # rate_limit is not overridden on the CLI, so the file value persists.
+    assert captured["rate_limit"] == 12
+
+
+def test_export_subcommand_from_cache(monkeypatch, tmp_path):
+    """The ``export`` subcommand re-exports from an existing cache, no crawling."""
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    db_name = utils.url_to_filename("http://example.com") + ".sqlite"
+    db = DatabaseManager(str(cache / db_name))
+    db.insert_page(
+        "http://example.com",
+        "# Page\n\nHello body",
+        json.dumps({"title": "Page"}),
+    )
+    db.insert_link("http://example.com", visited=True)
+    db.close()
+
+    out = tmp_path / "out"
+    args = [
+        "prog",
+        "export",
+        "--url",
+        "http://example.com",
+        "--cache-folder",
+        str(cache),
+        "--output-folder",
+        str(out),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    cli.main()
+
+    md_files = list(out.rglob("*.md"))
+    json_files = list(out.rglob("*.json"))
+    assert md_files, "expected a markdown export"
+    assert json_files, "expected a json export"
+    assert any("Hello body" in path.read_text() for path in md_files)
+
+
+def test_export_subcommand_missing_cache(monkeypatch, tmp_path):
+    """Exporting against a non-existent cache fails with a clean usage error."""
+    args = [
+        "prog",
+        "export",
+        "--url",
+        "http://example.com",
+        "--cache-folder",
+        str(tmp_path / "nope"),
+        "--output-folder",
+        str(tmp_path / "out"),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    with pytest.raises(SystemExit):
+        cli.main()
+
+
+def test_crawl_library_returns_pages(monkeypatch, tmp_path):
+    """The library ``crawl()`` runs with no argv and returns structured pages."""
+
+    def fake_scrape(self, url=None, urls_list=None):
+        target = url or (urls_list[0] if urls_list else None)
+        self.db_manager.insert_page(
+            target, "# Hello\n\nWorld", json.dumps({"title": "Hello"})
+        )
+        self.db_manager.insert_link(target, visited=True)
+
+    monkeypatch.setattr(Scraper, "start_scraping", fake_scrape)
+
+    result = crawl("http://example.com", cache_folder=str(tmp_path / "cache"))
+    assert result.pages
+    assert result.pages[0]["content"].startswith("# Hello")
+    assert result.pages[0]["metadata"]["title"] == "Hello"
+    assert result.stats.pages_stored == 1
+    # Library default: no compiled exports are written.
+    assert result.exports == {}
+
+
+def test_crawl_library_no_url_raises_without_exit():
+    """The library path raises ``ValueError`` instead of calling ``sys.exit``."""
+    with pytest.raises(ValueError):
+        crawl()


### PR DESCRIPTION
## Summary

End-to-end implementation of the "dream roadmap" (`.omc/plans/dream-roadmap.md`), executed in quality-gated phases (P0 → P3 subset). Every phase landed with tests green and `ruff` clean before the next began. **31 commits, atomic and conventional.**

Test suite grew **40 → 115** (all green; bare CI env stays green via `importorskip`/monkeypatch on optional extras).

## What changed, by phase

### P0 — Foundation (hygiene + real defect fixes + tooling)
- **Bug**: crawl-loop `session.get` was unguarded → one network error crashed the whole crawl. Now wrapped + every request has a timeout.
- **Bug**: O(n²) markdown assembly (`_cleanup_markdown` ran per page on the whole growing doc) → now a single pass.
- **Bug**: DB closed via `__del__` → now context manager + explicit `close()` + WAL.
- **Bug**: shared root-logger renamed by every module → per-module `logging.getLogger(__name__)`; logging configured in `main()`, not at import.
- Dead `old/` + `.history/` removed; `.gitignore` hardened; **CI workflow** added (ruff + pytest on 3.10–3.12); dev extras declared; README title fixed.

### P1 — Robustness
Retry with exponential backoff + jitter (429/5xx/`Retry-After`), `--timeout`, content-hash upsert (`fetched_at`, only rewrites on change), crawl bounds (`--max-pages/--max-depth/--max-time`), canonical URL dedup (tracking-param stripping, port/trailing-slash normalization). Legacy SQLite caches migrated additively.

### P1.5 — Async concurrency
`httpx.AsyncClient` engine behind `--concurrency N` (N=1 = byte-for-byte sync path, retained). SQLite touched only from the main coroutine; network runs concurrently under a semaphore. **Parity test** asserts identical corpus sync vs async.

### P2 — Crawl intelligence + AI-ready outputs
- Intelligence: `robots.txt` (default on, `--ignore-robots`), `--user-agent`, `--sitemap`, `--extract readability` (extra), `--render` (extra, Playwright), `--header/--cookie/--auth`, `--allow-types` (PDF/docx via MarkItDown). Applied to both sync + async paths.
- Outputs (§5): `--export-jsonl`, `--export-llms` (llms.txt + llms-full.txt), YAML frontmatter, token-aware RAG chunking (extra), token accounting, Parquet vector export (extra), end-of-run summary.

### P2.5 — Plugin system
Entry-point registry + `Formatter/Filter/Processor/Fetcher` protocols. Formatters wired live (output byte-identical); other groups have protocols + first-party impls + an example third-party plugin proven via a test. See `docs/plugins.md`.

### P3 (subset) — Interfaces
- Subcommands `crawl|export|mcp` with backward-compat (`crawler-to-md --url …` still works); `crawler-to-md.toml` config (CLI overrides file).
- **Library API**: `from crawler_to_md import crawl(...)` → `CrawlResult`, no CLI side effects; shared orchestration in `core.py`.
- **MCP server** (`crawler-to-md mcp`, extra `mcp`) exposing `crawl` and `fetch_as_markdown` tools.

## Optional extras
`readability` (trafilatura), `render` (playwright), `rag` (tiktoken), `vector` (pyarrow), `mcp`, `dev`. Core install stays light; all gated features lazy-import with a clear error if the extra is missing.

## Deferred / follow-ups (intentional, for honesty)
- `filter/processor/fetcher` plugin protocols exist + are tested but are **not yet consumed by the live crawl loop** (deferred to avoid regression risk).
- Sitemap XML parsed with stdlib `ElementTree`; consider `defusedxml` (or a size/depth guard) for untrusted input.
- HTTP service + web UI and the incremental scheduler were explicitly out of scope for this batch.

## Verification
- `ruff check .` clean.
- `pytest`: **115 passed** with all extras installed; bare dev env green (optional-extra tests skip/guard).
- Backward compatibility preserved: all pre-existing CLI flags and the bare `--url` invocation still work.
